### PR TITLE
check if channel is closed before continuing

### DIFF
--- a/modules/unique_session.go
+++ b/modules/unique_session.go
@@ -54,9 +54,13 @@ func NewUniqueSession(server *cluster.Server, rpcServer *cluster.NatsRPCServer, 
 }
 
 func (u *UniqueSession) processBindings(bindingsChan chan *nats.Msg) {
+loop:
 	for {
 		select {
-		case s := <-bindingsChan:
+		case s, ok := <-bindingsChan:
+			if !ok {
+				break loop
+			}
 			msgData := s.Data
 			msg := &BindingMsg{}
 			err := json.Unmarshal(msgData, msg)


### PR DESCRIPTION
This is a race condition. When bindingsChan is closed [here](https://github.com/topfreegames/pitaya/blob/master/cluster/nats_rpc_server.go#L134), the s variable is nil and s.Data crashes. 

I made the `break loop` because the for loop would keep happening intensively when the channel is closed. 