### PR TITLE
using dieChan to close application

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -585,6 +585,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "7f5dd76648caba09dad67567b43e0b18d601a27ad3f2b34f31f36a08d0cd8de4"
+  inputs-digest = "8f069e50cf90b9e7d361860ae50f5af05b4a408911709dd64f69123d558fef52"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/app.go
+++ b/app.go
@@ -247,7 +247,7 @@ func startDefaultSD() {
 
 func startDefaultRPCServer() {
 	// initialize default rpc server
-	rpcServer, err := cluster.NewNatsRPCServer(app.config, app.server, app.metricsReporters)
+	rpcServer, err := cluster.NewNatsRPCServer(app.config, app.server, app.metricsReporters, app.dieChan)
 	if err != nil {
 		logger.Log.Fatalf("error starting cluster rpc server component: %s", err.Error())
 	}
@@ -256,7 +256,7 @@ func startDefaultRPCServer() {
 
 func startDefaultRPCClient() {
 	// initialize default rpc client
-	rpcClient, err := cluster.NewNatsRPCClient(app.config, app.server, app.metricsReporters)
+	rpcClient, err := cluster.NewNatsRPCClient(app.config, app.server, app.metricsReporters, app.dieChan)
 	if err != nil {
 		logger.Log.Fatalf("error starting cluster rpc client component: %s", err.Error())
 	}

--- a/app_test.go
+++ b/app_test.go
@@ -80,10 +80,10 @@ func setup() {
 	etcdSD, _ := cluster.NewEtcdServiceDiscovery(app.config, app.server)
 	typeOfetcdSD = reflect.TypeOf(etcdSD)
 
-	natsRPCServer, _ := cluster.NewNatsRPCServer(app.config, app.server, nil)
+	natsRPCServer, _ := cluster.NewNatsRPCServer(app.config, app.server, nil, app.dieChan)
 	typeOfNatsRPCServer = reflect.TypeOf(natsRPCServer)
 
-	natsRPCClient, _ := cluster.NewNatsRPCClient(app.config, app.server, nil)
+	natsRPCClient, _ := cluster.NewNatsRPCClient(app.config, app.server, nil, app.dieChan)
 	typeOfNatsRPCClient = reflect.TypeOf(natsRPCClient)
 }
 
@@ -177,7 +177,7 @@ func TestSetHeartbeatInterval(t *testing.T) {
 func TestSetRPCServer(t *testing.T) {
 	initApp()
 	Configure(true, "testtype", Cluster, map[string]string{}, viper.New())
-	r, err := cluster.NewNatsRPCServer(app.config, app.server, nil)
+	r, err := cluster.NewNatsRPCServer(app.config, app.server, nil, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, r)
 
@@ -188,7 +188,7 @@ func TestSetRPCServer(t *testing.T) {
 func TestSetRPCClient(t *testing.T) {
 	initApp()
 	Configure(true, "testtype", Cluster, map[string]string{}, viper.New())
-	r, err := cluster.NewNatsRPCClient(app.config, app.server, nil)
+	r, err := cluster.NewNatsRPCClient(app.config, app.server, nil, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, r)
 	SetRPCClient(r)

--- a/cluster/nats_rpc_client_test.go
+++ b/cluster/nats_rpc_client_test.go
@@ -53,7 +53,7 @@ func TestNewNatsRPCClient(t *testing.T) {
 
 	cfg := getConfig()
 	sv := getServer()
-	n, err := NewNatsRPCClient(cfg, sv, mockMetricsReporters)
+	n, err := NewNatsRPCClient(cfg, sv, mockMetricsReporters, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, n)
 	assert.Equal(t, sv, n.server)
@@ -80,7 +80,7 @@ func TestNatsRPCClientConfigure(t *testing.T) {
 			cfg.Set("pitaya.cluster.rpc.client.nats.connect", table.natsConnect)
 			cfg.Set("pitaya.cluster.rpc.client.nats.requesttimeout", table.reqTimeout)
 			conf := getConfig(cfg)
-			_, err := NewNatsRPCClient(conf, getServer(), nil)
+			_, err := NewNatsRPCClient(conf, getServer(), nil, nil)
 			assert.Equal(t, table.err, err)
 		})
 	}
@@ -90,7 +90,7 @@ func TestNatsRPCClientGetSubscribeChannel(t *testing.T) {
 	t.Parallel()
 	cfg := getConfig()
 	sv := getServer()
-	n, _ := NewNatsRPCClient(cfg, sv, nil)
+	n, _ := NewNatsRPCClient(cfg, sv, nil, nil)
 	assert.Equal(t, fmt.Sprintf("pitaya/servers/%s/%s", n.server.Type, n.server.ID), n.getSubscribeChannel())
 }
 
@@ -98,7 +98,7 @@ func TestNatsRPCClientStop(t *testing.T) {
 	t.Parallel()
 	cfg := getConfig()
 	sv := getServer()
-	n, _ := NewNatsRPCClient(cfg, sv, nil)
+	n, _ := NewNatsRPCClient(cfg, sv, nil, nil)
 	// change it to true to ensure it goes to false
 	n.running = true
 	n.stop()
@@ -111,7 +111,7 @@ func TestNatsRPCClientInitShouldFailIfConnFails(t *testing.T) {
 	cfg := viper.New()
 	cfg.Set("pitaya.cluster.rpc.client.nats.connect", "nats://localhost:1")
 	config := getConfig(cfg)
-	rpcClient, _ := NewNatsRPCClient(config, sv, nil)
+	rpcClient, _ := NewNatsRPCClient(config, sv, nil, nil)
 	err := rpcClient.Init()
 	assert.Error(t, err)
 }
@@ -124,7 +124,7 @@ func TestNatsRPCClientInit(t *testing.T) {
 	config := getConfig(cfg)
 	sv := getServer()
 
-	rpcClient, _ := NewNatsRPCClient(config, sv, nil)
+	rpcClient, _ := NewNatsRPCClient(config, sv, nil, nil)
 	err := rpcClient.Init()
 	assert.NoError(t, err)
 	assert.True(t, rpcClient.running)
@@ -137,7 +137,7 @@ func TestNatsRPCClientInit(t *testing.T) {
 func TestNatsRPCClientSendShouldFailIfNotRunning(t *testing.T) {
 	config := getConfig()
 	sv := getServer()
-	rpcClient, _ := NewNatsRPCClient(config, sv, nil)
+	rpcClient, _ := NewNatsRPCClient(config, sv, nil, nil)
 	err := rpcClient.Send("topic", []byte("data"))
 	assert.Equal(t, constants.ErrRPCClientNotInitialized, err)
 }
@@ -150,7 +150,7 @@ func TestNatsRPCClientSend(t *testing.T) {
 	config := getConfig(cfg)
 	sv := getServer()
 
-	rpcClient, _ := NewNatsRPCClient(config, sv, nil)
+	rpcClient, _ := NewNatsRPCClient(config, sv, nil, nil)
 	rpcClient.Init()
 
 	tables := []struct {
@@ -182,7 +182,7 @@ func TestNatsRPCClientSend(t *testing.T) {
 func TestNatsRPCClientBuildRequest(t *testing.T) {
 	config := getConfig()
 	sv := getServer()
-	rpcClient, _ := NewNatsRPCClient(config, sv, nil)
+	rpcClient, _ := NewNatsRPCClient(config, sv, nil, nil)
 
 	rt := route.NewRoute("sv", "svc", "method")
 	ss := session.New(nil, true, "uid")
@@ -283,7 +283,7 @@ func TestNatsRPCClientBuildRequest(t *testing.T) {
 func TestNatsRPCClientCallShouldFailIfNotRunning(t *testing.T) {
 	config := getConfig()
 	sv := getServer()
-	rpcClient, _ := NewNatsRPCClient(config, sv, nil)
+	rpcClient, _ := NewNatsRPCClient(config, sv, nil, nil)
 	res, err := rpcClient.Call(context.Background(), protos.RPCType_Sys, nil, nil, nil, sv)
 	assert.Equal(t, constants.ErrRPCClientNotInitialized, err)
 	assert.Nil(t, res)
@@ -297,7 +297,7 @@ func TestNatsRPCClientCall(t *testing.T) {
 	cfg.Set("pitaya.cluster.rpc.client.nats.connect", fmt.Sprintf("nats://%s", s.Addr()))
 	cfg.Set("pitaya.cluster.rpc.client.nats.requesttimeout", "300ms")
 	config := getConfig(cfg)
-	rpcClient, _ := NewNatsRPCClient(config, sv, nil)
+	rpcClient, _ := NewNatsRPCClient(config, sv, nil, nil)
 	rpcClient.Init()
 
 	rt := route.NewRoute("sv", "svc", "method")
@@ -324,7 +324,7 @@ func TestNatsRPCClientCall(t *testing.T) {
 
 	for _, table := range tables {
 		t.Run(table.name, func(t *testing.T) {
-			conn, err := setupNatsConn(fmt.Sprintf("nats://%s", s.Addr()))
+			conn, err := setupNatsConn(fmt.Sprintf("nats://%s", s.Addr()), nil)
 			assert.NoError(t, err)
 
 			sv2 := getServer()

--- a/cluster/nats_rpc_server_test.go
+++ b/cluster/nats_rpc_server_test.go
@@ -45,7 +45,7 @@ func TestNewNatsRPCServer(t *testing.T) {
 
 	cfg := getConfig()
 	sv := getServer()
-	n, err := NewNatsRPCServer(cfg, sv, mockMetricsReporters)
+	n, err := NewNatsRPCServer(cfg, sv, mockMetricsReporters, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, n)
 	assert.Equal(t, sv, n.server)
@@ -74,7 +74,7 @@ func TestNatsRPCServerConfigure(t *testing.T) {
 			cfg.Set("pitaya.buffer.cluster.rpc.server.messages", table.messagesBufferSize)
 			cfg.Set("pitaya.buffer.cluster.rpc.server.push", table.pushBufferSize)
 			conf := getConfig(cfg)
-			_, err := NewNatsRPCServer(conf, getServer(), nil)
+			_, err := NewNatsRPCServer(conf, getServer(), nil, nil)
 			assert.Equal(t, table.err, err)
 		})
 	}
@@ -91,7 +91,7 @@ func TestNatsRPCServerGetUnhandledRequestsChannel(t *testing.T) {
 	t.Parallel()
 	cfg := getConfig()
 	sv := getServer()
-	n, _ := NewNatsRPCServer(cfg, sv, nil)
+	n, _ := NewNatsRPCServer(cfg, sv, nil, nil)
 	assert.NotNil(t, n.GetUnhandledRequestsChannel())
 	assert.IsType(t, make(chan *protos.Request), n.GetUnhandledRequestsChannel())
 }
@@ -100,7 +100,7 @@ func TestNatsRPCServerGetBindingsChannel(t *testing.T) {
 	t.Parallel()
 	cfg := getConfig()
 	sv := getServer()
-	n, _ := NewNatsRPCServer(cfg, sv, nil)
+	n, _ := NewNatsRPCServer(cfg, sv, nil, nil)
 	assert.Equal(t, n.bindingsChan, n.GetBindingsChannel())
 }
 
@@ -108,10 +108,10 @@ func TestNatsRPCServerSubscribeToBindingsChannel(t *testing.T) {
 	t.Parallel()
 	cfg := getConfig()
 	sv := getServer()
-	rpcServer, _ := NewNatsRPCServer(cfg, sv, nil)
+	rpcServer, _ := NewNatsRPCServer(cfg, sv, nil, nil)
 	s := helpers.GetTestNatsServer(t)
 	defer s.Shutdown()
-	conn, err := setupNatsConn(fmt.Sprintf("nats://%s", s.Addr()))
+	conn, err := setupNatsConn(fmt.Sprintf("nats://%s", s.Addr()), nil)
 	assert.NoError(t, err)
 	rpcServer.conn = conn
 	err = rpcServer.SubscribeToBindingsChannel()
@@ -126,7 +126,7 @@ func TestNatsRPCServerGetUserPushChannel(t *testing.T) {
 	t.Parallel()
 	cfg := getConfig()
 	sv := getServer()
-	n, _ := NewNatsRPCServer(cfg, sv, nil)
+	n, _ := NewNatsRPCServer(cfg, sv, nil, nil)
 	assert.NotNil(t, n.GetUserPushChannel())
 	assert.IsType(t, make(chan *protos.Push), n.GetUserPushChannel())
 }
@@ -134,10 +134,10 @@ func TestNatsRPCServerGetUserPushChannel(t *testing.T) {
 func TestNatsRPCServerSubscribeToUserMessages(t *testing.T) {
 	cfg := getConfig()
 	sv := getServer()
-	rpcServer, _ := NewNatsRPCServer(cfg, sv, nil)
+	rpcServer, _ := NewNatsRPCServer(cfg, sv, nil, nil)
 	s := helpers.GetTestNatsServer(t)
 	defer s.Shutdown()
-	conn, err := setupNatsConn(fmt.Sprintf("nats://%s", s.Addr()))
+	conn, err := setupNatsConn(fmt.Sprintf("nats://%s", s.Addr()), nil)
 	assert.NoError(t, err)
 	rpcServer.conn = conn
 	tables := []struct {
@@ -164,10 +164,10 @@ func TestNatsRPCServerSubscribeToUserMessages(t *testing.T) {
 func TestNatsRPCServerSubscribe(t *testing.T) {
 	cfg := getConfig()
 	sv := getServer()
-	rpcServer, _ := NewNatsRPCServer(cfg, sv, nil)
+	rpcServer, _ := NewNatsRPCServer(cfg, sv, nil, nil)
 	s := helpers.GetTestNatsServer(t)
 	defer s.Shutdown()
-	conn, err := setupNatsConn(fmt.Sprintf("nats://%s", s.Addr()))
+	conn, err := setupNatsConn(fmt.Sprintf("nats://%s", s.Addr()), nil)
 	assert.NoError(t, err)
 	rpcServer.conn = conn
 	tables := []struct {
@@ -199,10 +199,10 @@ func TestNatsRPCServerHandleMessages(t *testing.T) {
 	mockMetricsReporter := metricsmocks.NewMockReporter(ctrl)
 	mockMetricsReporters := []metrics.Reporter{mockMetricsReporter}
 
-	rpcServer, _ := NewNatsRPCServer(cfg, sv, mockMetricsReporters)
+	rpcServer, _ := NewNatsRPCServer(cfg, sv, mockMetricsReporters, nil)
 	s := helpers.GetTestNatsServer(t)
 	defer s.Shutdown()
-	conn, err := setupNatsConn(fmt.Sprintf("nats://%s", s.Addr()))
+	conn, err := setupNatsConn(fmt.Sprintf("nats://%s", s.Addr()), nil)
 	assert.NoError(t, err)
 	rpcServer.conn = conn
 	tables := []struct {
@@ -240,7 +240,7 @@ func TestNatsRPCServerInitShouldFailIfConnFails(t *testing.T) {
 	cfg.Set("pitaya.cluster.rpc.server.nats.connect", "nats://localhost:1")
 	config := getConfig(cfg)
 	sv := getServer()
-	rpcServer, _ := NewNatsRPCServer(config, sv, nil)
+	rpcServer, _ := NewNatsRPCServer(config, sv, nil, nil)
 	err := rpcServer.Init()
 	assert.Error(t, err)
 }
@@ -252,7 +252,7 @@ func TestNatsRPCServerInit(t *testing.T) {
 	cfg.Set("pitaya.cluster.rpc.server.nats.connect", fmt.Sprintf("nats://%s", s.Addr()))
 	config := getConfig(cfg)
 	sv := getServer()
-	rpcServer, _ := NewNatsRPCServer(config, sv, nil)
+	rpcServer, _ := NewNatsRPCServer(config, sv, nil, nil)
 	err := rpcServer.Init()
 	assert.NoError(t, err)
 	// should setup conn
@@ -293,7 +293,7 @@ func TestNatsRPCServerReportMetrics(t *testing.T) {
 	mockMetricsReporter := metricsmocks.NewMockReporter(ctrl)
 	mockMetricsReporters := []metrics.Reporter{mockMetricsReporter}
 
-	rpcServer, _ := NewNatsRPCServer(cfg, sv, mockMetricsReporters)
+	rpcServer, _ := NewNatsRPCServer(cfg, sv, mockMetricsReporters, nil)
 	rpcServer.dropped = 100
 	rpcServer.messagesBufferSize = 100
 	rpcServer.pushBufferSize = 100


### PR DESCRIPTION
Change the way nats module closes the application when it can't reconnect anymore. 

Also, made a test on `cluster/nats_rpc_common_test.go` to make sure the appDieChan is being closed when can't reconnect after 1 retry. 