### PR TITLE
send default tags on reporter

### DIFF
--- a/app.go
+++ b/app.go
@@ -137,13 +137,13 @@ func Configure(
 	app.messageEncoder = message.NewMessagesEncoder(app.config.GetBool("pitaya.handler.messages.compression"))
 	app.configured = true
 	app.metricsReporters = make([]metrics.Reporter, 0)
-	AddMetricsReporter(metrics.GetPrometheusReporter(serverType, app.config.GetString("pitaya.game"), app.config.GetInt("pitaya.metrics.prometheus.port")))
+
+	defaultTags := app.config.GetStringMapString("pitaya.metrics.tags")
+	AddMetricsReporter(metrics.GetPrometheusReporter(serverType, app.config.GetString("pitaya.game"), app.config.GetInt("pitaya.metrics.prometheus.port"), defaultTags))
 
 	if app.config.GetBool("pitaya.metrics.statsd.enabled") {
-		logger.Log.Infof(
-			"statsd is enabled, configuring the metrics reporter with host: %s",
-			app.config.Get("pitaya.metrics.statsd.host"))
-		metricsReporter, err := metrics.NewStatsdReporter(app.config, serverType)
+		logger.Log.Infof("statsd is enabled, configuring the metrics reporter with host: %s", app.config.Get("pitaya.metrics.statsd.host"))
+		metricsReporter, err := metrics.NewStatsdReporter(app.config, serverType, defaultTags)
 		if err != nil {
 			logger.Log.Errorf("failed to start statds metrics reporter, skipping %v", err)
 		} else {

--- a/app_test.go
+++ b/app_test.go
@@ -232,7 +232,9 @@ func TestSetServiceDiscovery(t *testing.T) {
 func TestAddMetricsReporter(t *testing.T) {
 	initApp()
 	Configure(true, "testtype", Cluster, map[string]string{}, viper.New())
-	r, err := metrics.NewStatsdReporter(app.config, app.server.Type)
+	r, err := metrics.NewStatsdReporter(app.config, app.server.Type, map[string]string{
+		"tag1": "value1",
+	})
 	assert.NoError(t, err)
 	assert.NotNil(t, r)
 	AddMetricsReporter(r)

--- a/config/config.go
+++ b/config/config.go
@@ -81,6 +81,7 @@ func (c *Config) fillDefaultValues() {
 		"pitaya.metrics.statsd.prefix":                          "pitaya.",
 		"pitaya.metrics.statsd.rate":                            1,
 		"pitaya.metrics.prometheus.port":                        9090,
+		"pitaya.metrics.tags":                                   map[string]string{},
 	}
 
 	for param := range defaultsMap {
@@ -118,4 +119,9 @@ func (c *Config) GetStringSlice(s string) []string {
 // Get returns an interface from the inner config
 func (c *Config) Get(s string) interface{} {
 	return c.config.Get(s)
+}
+
+// GetStringMapString returns a string map string from the inner config
+func (c *Config) GetStringMapString(s string) map[string]string {
+	return c.config.GetStringMapString(s)
 }

--- a/metrics/statsd_reporter_test.go
+++ b/metrics/statsd_reporter_test.go
@@ -39,7 +39,7 @@ func TestNewStatsdReporter(t *testing.T) {
 	mockClient := metricsmocks.NewMockClient(ctrl)
 
 	cfg := config.NewConfig()
-	sr, err := NewStatsdReporter(cfg, "svType", mockClient)
+	sr, err := NewStatsdReporter(cfg, "svType", map[string]string{}, mockClient)
 	assert.NoError(t, err)
 	assert.Equal(t, mockClient, sr.client)
 	assert.Equal(t, float64(cfg.GetInt("pitaya.metrics.statsd.rate")), sr.rate)
@@ -53,7 +53,9 @@ func TestReportLatency(t *testing.T) {
 	mockClient := metricsmocks.NewMockClient(ctrl)
 
 	cfg := config.NewConfig()
-	sr, err := NewStatsdReporter(cfg, "svType", mockClient)
+	sr, err := NewStatsdReporter(cfg, "svType", map[string]string{
+		"defaultTag": "value",
+	}, mockClient)
 	assert.NoError(t, err)
 
 	expectedDuration, err := time.ParseDuration("200ms")
@@ -67,6 +69,7 @@ func TestReportLatency(t *testing.T) {
 		assert.Contains(t, tags, fmt.Sprintf("type:%s", expectedType))
 		assert.Contains(t, tags, fmt.Sprintf("status:%s", expectedErrored))
 		assert.Contains(t, tags, fmt.Sprintf("serverType:%s", sr.serverType))
+		assert.Contains(t, tags, "defaultTag:value")
 	})
 
 	err = sr.ReportSummary(ResponseTime, map[string]string{
@@ -84,7 +87,7 @@ func TestReportLatencyError(t *testing.T) {
 	mockClient := metricsmocks.NewMockClient(ctrl)
 
 	cfg := config.NewConfig()
-	sr, err := NewStatsdReporter(cfg, "svType", mockClient)
+	sr, err := NewStatsdReporter(cfg, "svType", map[string]string{}, mockClient)
 	assert.NoError(t, err)
 
 	expectedError := errors.New("some error")
@@ -100,7 +103,9 @@ func TestReportCount(t *testing.T) {
 	mockClient := metricsmocks.NewMockClient(ctrl)
 
 	cfg := config.NewConfig()
-	sr, err := NewStatsdReporter(cfg, "svType", mockClient)
+	sr, err := NewStatsdReporter(cfg, "svType", map[string]string{
+		"defaultTag": "value",
+	}, mockClient)
 	assert.NoError(t, err)
 
 	expectedCount := 123
@@ -115,6 +120,7 @@ func TestReportCount(t *testing.T) {
 		}
 		assert.Contains(t, tags, fmt.Sprintf("serverType:%s", sr.serverType))
 		assert.Contains(t, tags, fmt.Sprintf("hostname:%s", sr.hostname))
+		assert.Contains(t, tags, "defaultTag:value")
 	})
 
 	err = sr.ReportCount(expectedMetric, customTags, float64(expectedCount))
@@ -127,7 +133,7 @@ func TestReportCountError(t *testing.T) {
 	mockClient := metricsmocks.NewMockClient(ctrl)
 
 	cfg := config.NewConfig()
-	sr, err := NewStatsdReporter(cfg, "svType", mockClient)
+	sr, err := NewStatsdReporter(cfg, "svType", map[string]string{}, mockClient)
 	assert.NoError(t, err)
 
 	expectedError := errors.New("some error")


### PR DESCRIPTION
I would like to choose new tags (or labels, on Prometheus) to send to StatsD and Prometheus. This PR adds a new field on config to get these default tags and sends them on every metric. 