### PR TITLE
[DONE] Create IncomingMsgChan only on ConnectTo

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -104,7 +104,6 @@ func New(logLevel logrus.Level, requestTimeout ...time.Duration) *Client {
 		packetEncoder:   codec.NewPomeloPacketEncoder(),
 		packetDecoder:   codec.NewPomeloPacketDecoder(),
 		packetChan:      make(chan *packet.Packet, 10),
-		IncomingMsgChan: make(chan *message.Message, 10),
 		pendingRequests: make(map[uint]*pendingRequest),
 		requestTimeout:  reqTimeout,
 		// 30 here is the limit of inflight messages

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -37,6 +37,8 @@ func TestSendRequestShouldTimeout(t *testing.T) {
 
 	mockConn.EXPECT().Write(pkt)
 
+	c.IncomingMsgChan = make(chan *message.Message, 10)
+
 	c.nextID = 0
 	c.SendRequest(route, data)
 


### PR DESCRIPTION
This PR fixes a bug on pitaya-client.
The New function no longer creates the IncomingMsgChan.
The problem with the old implementation was: This channel was already being created
inside the connectTo method. This means that if a client starts listenning to the channel before a  call to connectTo, the old channel would leak and the messages would not be received by the client.
