### PR TITLE
do not stop sessions and handlers on appDieChan

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -264,8 +264,6 @@ func (a *Agent) Handle() {
 	select {
 	case <-a.chDie: // agent closed signal
 		return
-	case <-a.appDieChan: // application quit
-		return
 	}
 }
 

--- a/service/handler.go
+++ b/service/handler.go
@@ -132,9 +132,6 @@ func (h *HandlerService) Dispatch(thread int) {
 
 		case id := <-timer.Manager.ChClosingTimer: // closing Timers
 			timer.RemoveTimer(id)
-
-		case <-h.appDieChan: // application quit signal
-			return
 		}
 	}
 }


### PR DESCRIPTION
### Do not return on Agent

Agent handles client sessions. When appDieChan is closed, the Handle method returns and all clients are disconnected. This stops every graceful shutdown that may be happening. BY not returning, clients keep connected to finish their requests or make new ones during the graceful shutdown period.

### Do not return on Handler

Handler executes the requests. During graceful shutdown clients may need to make new requests, for exemplo a call do matchEnded from a binary module. 

### Conclusion

By doing this, the connections will only be dropped when the pitaya server actually stops. 