### PR TITLE
[DONE] Fix concurrently closing and writing to the same chan

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -301,7 +301,6 @@ func (c *Client) Disconnect() {
 	if c.Connected {
 		c.Connected = false
 		close(c.closeChan)
-		close(c.IncomingMsgChan)
 		c.conn.Close()
 	}
 }


### PR DESCRIPTION
## Problem
The go client spawns two goroutines: handlePackets and pendingRequestsReaper

They both write to client.IncomingMsgChan.
The problem is: the client.Disconnect method was closing the IncomingMsgChan
and there is no way for the handlePackets and pendingRequestReaper goroutines to know 
that this happened.
When one of these 2 goroutines tries to write to the closed channel the application panics.

## Solution
I'm not completely sure that just not closing the IncomingMsgChan is the correct solution
but in some articles like [this](https://go101.org/article/channel-closing.html) there is a 'rule' to only close channels from the writer goroutine.

