### PR TITLE
ordered modules

### DIFF
--- a/app.go
+++ b/app.go
@@ -338,9 +338,9 @@ func Start() {
 			app.serviceDiscovery.AddListener(app.rpcClient.(*cluster.GRPCClient))
 		}
 
-		RegisterModule(app.serviceDiscovery, "serviceDiscovery")
-		RegisterModule(app.rpcServer, "rpcServer")
-		RegisterModule(app.rpcClient, "rpcClient")
+		RegisterModuleBefore(app.serviceDiscovery, "serviceDiscovery")
+		RegisterModuleBefore(app.rpcServer, "rpcServer")
+		RegisterModuleBefore(app.rpcClient, "rpcClient")
 
 		app.router.SetServiceDiscovery(app.serviceDiscovery)
 

--- a/app.go
+++ b/app.go
@@ -338,9 +338,18 @@ func Start() {
 			app.serviceDiscovery.AddListener(app.rpcClient.(*cluster.GRPCClient))
 		}
 
-		RegisterModuleBefore(app.serviceDiscovery, "serviceDiscovery")
-		RegisterModuleBefore(app.rpcServer, "rpcServer")
-		RegisterModuleBefore(app.rpcClient, "rpcClient")
+		err := RegisterModuleBefore(app.serviceDiscovery, "serviceDiscovery")
+		if err != nil {
+			logger.Log.Fatal("failed to register service discovery module: %s", err.Error())
+		}
+		err = RegisterModuleBefore(app.rpcServer, "rpcServer")
+		if err != nil {
+			logger.Log.Fatal("failed to register rpc server module: %s", err.Error())
+		}
+		err = RegisterModuleBefore(app.rpcClient, "rpcClient")
+		if err != nil {
+			logger.Log.Fatal("failed to register rpc client module: %s", err.Error())
+		}
 
 		app.router.SetServiceDiscovery(app.serviceDiscovery)
 

--- a/module_test.go
+++ b/module_test.go
@@ -32,20 +32,27 @@ import (
 type MyMod struct {
 	component.Base
 	running bool
+	name    string
+}
+
+var modulesOrder []string
+
+func resetModules() {
+	modulesMap = make(map[string]interfaces.Module)
+	modulesArr = []moduleWrapper{}
+	modulesOrder = []string{}
 }
 
 func (m *MyMod) Init() error {
 	m.running = true
+	modulesOrder = append(modulesOrder, m.name)
 	return nil
 }
 
 func (m *MyMod) Shutdown() error {
 	m.running = false
+	modulesOrder = append(modulesOrder, m.name)
 	return nil
-}
-
-func resetModules() {
-	modules = make(map[string]interfaces.Module)
 }
 
 func TestRegisterModule(t *testing.T) {
@@ -53,8 +60,11 @@ func TestRegisterModule(t *testing.T) {
 	b := &MyMod{}
 	err := RegisterModule(b, "mod")
 	assert.NoError(t, err)
-	assert.Equal(t, 1, len(modules))
-	assert.Equal(t, b, modules["mod"])
+	assert.Equal(t, 1, len(modulesMap))
+	assert.Equal(t, b, modulesMap["mod"])
+	assert.Equal(t, 1, len(modulesArr))
+	assert.Equal(t, "mod", modulesArr[0].name)
+	assert.Equal(t, b, modulesArr[0].module)
 	err = RegisterModule(b, "mod")
 	assert.Error(t, err)
 }
@@ -76,9 +86,17 @@ func TestStartupModules(t *testing.T) {
 	resetModules()
 	Configure(true, "testtype", Standalone, map[string]string{}, viper.New())
 
-	RegisterModule(&MyMod{}, "bla")
+	RegisterModule(&MyMod{name: "mod1"}, "mod1")
+	RegisterModuleBefore(&MyMod{name: "mod2"}, "mod2")
+	RegisterModuleBefore(&MyMod{name: "mod3"}, "mod3")
+	RegisterModuleAfter(&MyMod{name: "mod4"}, "mod4")
+
 	startModules()
-	assert.Equal(t, true, modules["bla"].(*MyMod).running)
+	assert.Equal(t, true, modulesMap["mod1"].(*MyMod).running)
+	assert.Equal(t, true, modulesMap["mod2"].(*MyMod).running)
+	assert.Equal(t, true, modulesMap["mod3"].(*MyMod).running)
+	assert.Equal(t, true, modulesMap["mod4"].(*MyMod).running)
+	assert.Equal(t, []string{"mod3", "mod2", "mod1", "mod4"}, modulesOrder)
 }
 
 func TestShutdownModules(t *testing.T) {
@@ -86,9 +104,17 @@ func TestShutdownModules(t *testing.T) {
 	initApp()
 	Configure(true, "testtype", Standalone, map[string]string{}, viper.New())
 
-	RegisterModule(&MyMod{}, "bla")
+	RegisterModule(&MyMod{name: "mod1"}, "mod1")
+	RegisterModuleBefore(&MyMod{name: "mod2"}, "mod2")
+	RegisterModuleBefore(&MyMod{name: "mod3"}, "mod3")
+	RegisterModuleAfter(&MyMod{name: "mod4"}, "mod4")
 	startModules()
 
+	modulesOrder = []string{}
 	shutdownModules()
-	assert.Equal(t, false, modules["bla"].(*MyMod).running)
+	assert.Equal(t, false, modulesMap["mod1"].(*MyMod).running)
+	assert.Equal(t, false, modulesMap["mod2"].(*MyMod).running)
+	assert.Equal(t, false, modulesMap["mod3"].(*MyMod).running)
+	assert.Equal(t, false, modulesMap["mod4"].(*MyMod).running)
+	assert.Equal(t, []string{"mod4", "mod1", "mod2", "mod3"}, modulesOrder)
 }

--- a/module_test.go
+++ b/module_test.go
@@ -86,10 +86,14 @@ func TestStartupModules(t *testing.T) {
 	resetModules()
 	Configure(true, "testtype", Standalone, map[string]string{}, viper.New())
 
-	RegisterModule(&MyMod{name: "mod1"}, "mod1")
-	RegisterModuleBefore(&MyMod{name: "mod2"}, "mod2")
-	RegisterModuleBefore(&MyMod{name: "mod3"}, "mod3")
-	RegisterModuleAfter(&MyMod{name: "mod4"}, "mod4")
+	err := RegisterModule(&MyMod{name: "mod1"}, "mod1")
+	assert.NoError(t, err)
+	err = RegisterModuleBefore(&MyMod{name: "mod2"}, "mod2")
+	assert.NoError(t, err)
+	err = RegisterModuleBefore(&MyMod{name: "mod3"}, "mod3")
+	assert.NoError(t, err)
+	err = RegisterModuleAfter(&MyMod{name: "mod4"}, "mod4")
+	assert.NoError(t, err)
 
 	startModules()
 	assert.Equal(t, true, modulesMap["mod1"].(*MyMod).running)
@@ -104,10 +108,15 @@ func TestShutdownModules(t *testing.T) {
 	initApp()
 	Configure(true, "testtype", Standalone, map[string]string{}, viper.New())
 
-	RegisterModule(&MyMod{name: "mod1"}, "mod1")
-	RegisterModuleBefore(&MyMod{name: "mod2"}, "mod2")
-	RegisterModuleBefore(&MyMod{name: "mod3"}, "mod3")
-	RegisterModuleAfter(&MyMod{name: "mod4"}, "mod4")
+	err := RegisterModule(&MyMod{name: "mod1"}, "mod1")
+	assert.NoError(t, err)
+	err = RegisterModuleBefore(&MyMod{name: "mod2"}, "mod2")
+	assert.NoError(t, err)
+	err = RegisterModuleBefore(&MyMod{name: "mod3"}, "mod3")
+	assert.NoError(t, err)
+	err = RegisterModuleAfter(&MyMod{name: "mod4"}, "mod4")
+	assert.NoError(t, err)
+
 	startModules()
 
 	modulesOrder = []string{}


### PR DESCRIPTION
Initialise modules in order, in case the binary modules needs to use rpc client module for example.

I introduced the function RegisterModuleBefore, so don't force the developer to initialise and register a module before others.