### PR TITLE
[Done] Pipeline now receives the decoded arguments insted of raw data

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -180,6 +180,25 @@
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:e1ff887e232b2d8f4f7c7db15a5fac7be418025afc4dda53c59c765dbb5aa6b4"
+  name = "github.com/go-playground/locales"
+  packages = [
+    ".",
+    "currency",
+  ]
+  pruneopts = "UT"
+  revision = "f63010822830b6fe52288ee52d5a1151088ce039"
+  version = "v0.12.1"
+
+[[projects]]
+  digest = "1:e022cf244bcac1b6ef933f1a2e0adcf6a6dfd7b872d8d41e4d4179bb09a87cbc"
+  name = "github.com/go-playground/universal-translator"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "b32fa301c9fe55953584134cb6853a13c87ec0a1"
+  version = "v0.16.0"
+
+[[projects]]
   digest = "1:bfc758d5a03d57d97226fac6934551c01bd76612adb119c177395b057a0a46db"
   name = "github.com/gogo/protobuf"
   packages = [
@@ -683,6 +702,14 @@
   version = "v1.10.0"
 
 [[projects]]
+  digest = "1:e2f64cca6e235f32cd4c2f9be9ae0cda1f8608fc6fdb68936e8d10e4e0bb074d"
+  name = "gopkg.in/go-playground/validator.v9"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "e69e9a28bb62b977fdc58d051f1bb477b7cbe486"
+  version = "v9.21.0"
+
+[[projects]]
   digest = "1:342378ac4dcb378a5448dd723f0784ae519383532f5e70ade24132c4c8693202"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
@@ -716,6 +743,7 @@
     "github.com/uber/jaeger-client-go/config",
     "golang.org/x/net/context",
     "google.golang.org/grpc",
+    "gopkg.in/go-playground/validator.v9",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/examples/demo/chat/main.go
+++ b/examples/demo/chat/main.go
@@ -25,7 +25,6 @@ type (
 		component.Base
 		group *pitaya.Group
 		timer *timer.Timer
-		stats *stats
 	}
 
 	// UserMessage represents a message that user sent
@@ -49,28 +48,12 @@ type (
 		Code   int    `json:"code"`
 		Result string `json:"result"`
 	}
-
-	stats struct {
-		outboundBytes int
-		inboundBytes  int
-	}
 )
-
-func (stats *stats) outbound(ctx context.Context, in []byte) ([]byte, error) {
-	stats.outboundBytes += len(in)
-	return in, nil
-}
-
-func (stats *stats) inbound(ctx context.Context, in []byte) ([]byte, error) {
-	stats.inboundBytes += len(in)
-	return in, nil
-}
 
 // NewRoom returns a new room
 func NewRoom() *Room {
 	return &Room{
 		group: pitaya.NewGroup("room"),
-		stats: &stats{},
 	}
 }
 
@@ -78,8 +61,6 @@ func NewRoom() *Room {
 func (r *Room) AfterInit() {
 	r.timer = pitaya.NewTimer(time.Minute, func() {
 		println("UserCount: Time=>", time.Now().String(), "Count=>", r.group.Count())
-		println("OutboundBytes", r.stats.outboundBytes)
-		println("InboundBytes", r.stats.outboundBytes)
 	})
 }
 
@@ -128,10 +109,6 @@ func main() {
 		component.WithName("room"),
 		component.WithNameFunc(strings.ToLower),
 	)
-
-	// traffic stats
-	pitaya.AfterHandler(room.stats.outbound)
-	pitaya.BeforeHandler(room.stats.inbound)
 
 	log.SetFlags(log.LstdFlags | log.Llongfile)
 

--- a/examples/demo/cluster/main.go
+++ b/examples/demo/cluster/main.go
@@ -27,10 +27,6 @@ func configureBackend() {
 		component.WithName("room"),
 		component.WithNameFunc(strings.ToLower),
 	)
-
-	// traffic stats
-	pitaya.AfterHandler(room.Stats.Outbound)
-	pitaya.BeforeHandler(room.Stats.Inbound)
 }
 
 func configureFrontend(port int) {

--- a/examples/demo/cluster_grpc/main.go
+++ b/examples/demo/cluster_grpc/main.go
@@ -30,10 +30,6 @@ func configureBackend() {
 		component.WithName("room"),
 		component.WithNameFunc(strings.ToLower),
 	)
-
-	// traffic stats
-	pitaya.AfterHandler(room.Stats.Outbound)
-	pitaya.BeforeHandler(room.Stats.Inbound)
 }
 
 func configureFrontend(port int) {

--- a/examples/demo/cluster_protobuf/main.go
+++ b/examples/demo/cluster_protobuf/main.go
@@ -24,10 +24,6 @@ func configureBackend() {
 		component.WithName("room"),
 		component.WithNameFunc(strings.ToLower),
 	)
-
-	// traffic stats
-	pitaya.AfterHandler(room.Stats.Outbound)
-	pitaya.BeforeHandler(room.Stats.Inbound)
 }
 
 func configureFrontend(port int) {

--- a/examples/demo/pipeline/main.go
+++ b/examples/demo/pipeline/main.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	"github.com/topfreegames/pitaya"
+	"github.com/topfreegames/pitaya/acceptor"
+	"github.com/topfreegames/pitaya/component"
+	"github.com/topfreegames/pitaya/serialize/json"
+	validator "gopkg.in/go-playground/validator.v9"
+)
+
+// MetagameServer ...
+type MetagameServer struct {
+	component.Base
+	Logger logrus.FieldLogger
+}
+
+// NewMetagameMock ...
+func NewMetagameMock() *MetagameServer {
+	return &MetagameServer{
+		Logger: logrus.New(),
+	}
+}
+
+// CreatePlayerCheatArgs ...
+type CreatePlayerCheatArgs struct {
+	Name         string `json:"name"`
+	Email        string `json:"email" validate:"email"`
+	SoftCurrency int    `json:"softCurrency" validate:"gte=0,lte=1000"`
+	HardCurrency int    `json:"hardCurrency" validate:"gte=0,lte=200"`
+}
+
+// CreatePlayerCheatResponse ...
+type CreatePlayerCheatResponse struct {
+	Msg string `json:"msg"`
+}
+
+// CreatePlayerCheat ...
+func (g *MetagameServer) CreatePlayerCheat(ctx context.Context, args *CreatePlayerCheatArgs) (*CreatePlayerCheatResponse, error) {
+	// Do nothing. This is just an example of how pipelines can be helpful
+	return &CreatePlayerCheatResponse{
+		Msg: "ok",
+	}, nil
+}
+
+// This is a beforeHandler that validates the handler argument based on the struct tags.
+// As for this example, the CreatePlayerCheatArgs has the 'validate' tags for email,
+// softCurrency and hardCurrency. If any of the validations fail an error will be returned
+func handlerParamsValidator(ctx context.Context, in interface{}) (interface{}, error) {
+	var validate *validator.Validate
+	validate = validator.New()
+
+	if err := validate.Struct(in); err != nil {
+		return nil, err
+	}
+
+	return in, nil
+}
+
+// Simple example of a before pipeline that actually asserts the type of the
+// in parameter.
+// IMPORTANT: that this kind of pipeline will be hard to exist in real code
+// as a pipeline function executes for every handler and each of them
+// most probably have different parameter types.
+func (g *MetagameServer) simpleBefore(ctx context.Context, in interface{}) (interface{}, error) {
+	g.Logger.Info("Simple Before exec")
+	createPlayerArgs := in.(*CreatePlayerCheatArgs)
+
+	g.Logger.Infof("Name: %s", createPlayerArgs.Name)
+	g.Logger.Infof("Email: %s", createPlayerArgs.Email)
+	g.Logger.Infof("SoftCurrency: %d", createPlayerArgs.SoftCurrency)
+	g.Logger.Infof("HardCurrency: %d", createPlayerArgs.HardCurrency)
+
+	return in, nil
+}
+
+// Simple example of an after pipeline. The 2nd argument is the handler response.
+func (g *MetagameServer) simpleAfter(ctx context.Context, resp interface{}) (interface{}, error) {
+	g.Logger.Info("Simple After exec - response:", resp)
+
+	return resp, nil
+}
+
+func main() {
+	svType := flag.String("type", "metagameDemo", "the server type")
+	isFrontend := flag.Bool("frontend", true, "if server is frontend")
+	flag.Parse()
+
+	defer pitaya.Shutdown()
+
+	metagameServer := NewMetagameMock()
+	pitaya.SetSerializer(json.NewSerializer())
+	pitaya.Register(metagameServer,
+		component.WithName("metagameHandler"),
+	)
+
+	// Pipelines registration
+	pitaya.BeforeHandler(handlerParamsValidator)
+	pitaya.BeforeHandler(metagameServer.simpleBefore)
+	pitaya.AfterHandler(metagameServer.simpleAfter)
+
+	port := 3251
+	tcp := acceptor.NewTCPAcceptor(fmt.Sprintf(":%d", port))
+	pitaya.AddAcceptor(tcp)
+	pitaya.Configure(*isFrontend, *svType, pitaya.Cluster, map[string]string{})
+	pitaya.Start()
+}

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -32,7 +32,7 @@ var (
 type (
 	// Handler is a function that has the same signature as a handler and will
 	// be called before or after handler methods
-	Handler func(ctx context.Context, in []byte) (out []byte, err error)
+	Handler func(ctx context.Context, in interface{}) (out interface{}, err error)
 
 	pipelineChannel struct {
 		Handlers []Handler

--- a/pipeline/pipeline_test.go
+++ b/pipeline/pipeline_test.go
@@ -29,10 +29,10 @@ import (
 )
 
 var (
-	handler1 = func(ctx context.Context, in []byte) ([]byte, error) {
+	handler1 = func(ctx context.Context, in interface{}) (interface{}, error) {
 		return in, errors.New("ohno")
 	}
-	handler2 = func(ctx context.Context, in []byte) ([]byte, error) {
+	handler2 = func(ctx context.Context, in interface{}) (interface{}, error) {
 		return nil, nil
 	}
 	p = &pipelineChannel{}

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -33,7 +33,7 @@ func resetPipelines() {
 	pipeline.AfterHandler.Handlers = make([]pipeline.Handler, 0)
 }
 
-var myHandler = func(ctx context.Context, in []byte) ([]byte, error) {
+var myHandler = func(ctx context.Context, in interface{}) (interface{}, error) {
 	return []byte("test"), nil
 }
 

--- a/service/util.go
+++ b/service/util.go
@@ -96,7 +96,7 @@ func getMsgType(msgTypeIface interface{}) (message.Type, error) {
 	return msgType, nil
 }
 
-func executeBeforePipeline(ctx context.Context, data []byte) ([]byte, error) {
+func executeBeforePipeline(ctx context.Context, data interface{}) (interface{}, error) {
 	var err error
 	res := data
 	if len(pipeline.BeforeHandler.Handlers) > 0 {
@@ -114,7 +114,7 @@ func executeBeforePipeline(ctx context.Context, data []byte) ([]byte, error) {
 	return res, nil
 }
 
-func executeAfterPipeline(ctx context.Context, ser serialize.Serializer, res []byte) []byte {
+func executeAfterPipeline(ctx context.Context, ser serialize.Serializer, res interface{}) interface{} {
 	var err error
 	ret := res
 	if len(pipeline.AfterHandler.Handlers) > 0 {
@@ -170,13 +170,15 @@ func processHandlerMessage(
 		logger.Log.Warn(err.Error())
 	}
 
-	if data, err = executeBeforePipeline(ctx, data); err != nil {
-		return nil, err
-	}
-
+	// First unmarshal the handler arg that will be passed to
+	// both handler and pipeline functions
 	arg, err := unmarshalHandlerArg(h, serializer, data)
 	if err != nil {
 		return nil, e.NewError(err, e.ErrBadRequestCode)
+	}
+
+	if arg, err = executeBeforePipeline(ctx, arg); err != nil {
+		return nil, err
 	}
 
 	logger.Log.Debugf("SID=%d, Data=%s", session.ID(), data)
@@ -199,11 +201,11 @@ func processHandlerMessage(
 		resp = []byte("ack")
 	}
 
+	resp = executeAfterPipeline(ctx, serializer, resp)
 	ret, err := serializeReturn(serializer, resp)
 	if err != nil {
 		return nil, err
 	}
-	ret = executeAfterPipeline(ctx, serializer, ret)
 
 	return ret, nil
 }

--- a/service/util_test.go
+++ b/service/util_test.go
@@ -217,12 +217,12 @@ func TestExecuteBeforePipelineSuccess(t *testing.T) {
 	data := []byte("ok")
 	expected1 := []byte("oh noes 1")
 	expected2 := []byte("oh noes 2")
-	before1 := func(ctx context.Context, in []byte) ([]byte, error) {
+	before1 := func(ctx context.Context, in interface{}) (interface{}, error) {
 		assert.Equal(t, c, ctx)
 		assert.Equal(t, data, in)
 		return expected1, nil
 	}
-	before2 := func(ctx context.Context, in []byte) ([]byte, error) {
+	before2 := func(ctx context.Context, in interface{}) (interface{}, error) {
 		assert.Equal(t, c, ctx)
 		assert.Equal(t, expected1, in)
 		return expected2, nil
@@ -239,7 +239,7 @@ func TestExecuteBeforePipelineSuccess(t *testing.T) {
 func TestExecuteBeforePipelineError(t *testing.T) {
 	c := context.Background()
 	expected := errors.New("oh noes")
-	before := func(ctx context.Context, in []byte) ([]byte, error) {
+	before := func(ctx context.Context, in interface{}) (interface{}, error) {
 		assert.Equal(t, c, ctx)
 		return nil, expected
 	}
@@ -261,12 +261,12 @@ func TestExecuteAfterPipelineSuccess(t *testing.T) {
 	data := []byte("ok")
 	expected1 := []byte("oh noes 1")
 	expected2 := []byte("oh noes 2")
-	after1 := func(ctx context.Context, in []byte) ([]byte, error) {
+	after1 := func(ctx context.Context, in interface{}) (interface{}, error) {
 		assert.Equal(t, c, ctx)
 		assert.Equal(t, data, in)
 		return expected1, nil
 	}
-	after2 := func(ctx context.Context, in []byte) ([]byte, error) {
+	after2 := func(ctx context.Context, in interface{}) (interface{}, error) {
 		assert.Equal(t, c, ctx)
 		assert.Equal(t, expected1, in)
 		return expected2, nil
@@ -285,7 +285,7 @@ func TestExecuteAfterPipelineError(t *testing.T) {
 	mockSerializer := mocks.NewMockSerializer(ctrl)
 
 	c := context.Background()
-	after := func(ctx context.Context, in []byte) ([]byte, error) {
+	after := func(ctx context.Context, in interface{}) (interface{}, error) {
 		assert.Equal(t, c, ctx)
 		return nil, errors.New("oh noes")
 	}
@@ -407,7 +407,7 @@ func TestProcessHandlerMessageBrokenBeforePipeline(t *testing.T) {
 	handlers[rt.Short()] = &component.Handler{}
 	defer func() { delete(handlers, rt.Short()) }()
 	expected := errors.New("oh noes")
-	before := func(ctx context.Context, in []byte) ([]byte, error) {
+	before := func(ctx context.Context, in interface{}) (interface{}, error) {
 		return nil, expected
 	}
 	pipeline.BeforeHandler.PushFront(before)
@@ -428,7 +428,7 @@ func TestProcessHandlerMessageBrokenAfterPipeline(t *testing.T) {
 	handlers[rt.Short()] = &component.Handler{Receiver: reflect.ValueOf(tObj), Method: m, Type: m.Type.In(2)}
 	defer func() { delete(handlers, rt.Short()) }()
 
-	after := func(ctx context.Context, in []byte) ([]byte, error) {
+	after := func(ctx context.Context, in interface{}) (interface{}, error) {
 		return nil, errors.New("oh noes")
 	}
 	pipeline.AfterHandler.PushFront(after)


### PR DESCRIPTION
### This PR changes the signature of the pipeline handler.
The ideia is to make possible for pipelines to access the decoded struct from the message bytes.

#### Motivation
Make it possible to, for example, create pipelines for struct field validation (see the example added to /examples/demo/pipeline)

#### TODOs
- [x] Fix examples that used pipelines with the old signature 