### PR TITLE
[DONE] Add default logger to context on both handlers and remotes

### DIFF
--- a/app.go
+++ b/app.go
@@ -502,6 +502,11 @@ func GetSessionFromCtx(ctx context.Context) *session.Session {
 	return ctx.Value(constants.SessionCtxKey).(*session.Session)
 }
 
+// GetDefaultLoggerFromCtx returns the default logger from the given context
+func GetDefaultLoggerFromCtx(ctx context.Context) logger.Logger {
+	return ctx.Value(constants.LoggerCtxKey).(logger.Logger)
+}
+
 // AddToPropagateCtx adds a key and value that will be propagated through RPC calls
 func AddToPropagateCtx(ctx context.Context, key string, val interface{}) context.Context {
 	return pcontext.AddToPropagateCtx(ctx, key, val)

--- a/constants/const.go
+++ b/constants/const.go
@@ -46,6 +46,9 @@ const (
 // SessionCtxKey is the context key where the session will be set
 var SessionCtxKey = "session"
 
+// LoggerCtxKey is the context key where the default logger will be set
+var LoggerCtxKey = "default-logger"
+
 type propagateKey struct{}
 
 // PropagateCtxKey is the context key where the content that will be

--- a/service/util.go
+++ b/service/util.go
@@ -154,6 +154,8 @@ func processHandlerMessage(
 	remote bool,
 ) ([]byte, error) {
 	ctx = context.WithValue(ctx, constants.SessionCtxKey, session)
+	ctx = util.CtxWithDefaultLogger(ctx, rt.String(), session.UID())
+
 	h, err := getHandler(rt)
 	if err != nil {
 		return nil, e.NewError(err, e.ErrNotFoundCode)


### PR DESCRIPTION
This is an ideia: to have a default logger within each handler/remote ctx that already has some fields to help debugging.

As I'm not sure if this should be included directly on pitaya core I requested the review from all of you.

Could you please just give your opinions and possible alternatives for it?

### Goal
Have a default logger on each handler and remote with fields like: route, sessionsId, requestId