### PR TITLE
Add descriptors

### DIFF
--- a/app.go
+++ b/app.go
@@ -40,6 +40,7 @@ import (
 	"github.com/topfreegames/pitaya/constants"
 	pcontext "github.com/topfreegames/pitaya/context"
 	"github.com/topfreegames/pitaya/defaultpipelines"
+	"github.com/topfreegames/pitaya/docgenerator"
 	"github.com/topfreegames/pitaya/errors"
 	"github.com/topfreegames/pitaya/internal/codec"
 	"github.com/topfreegames/pitaya/internal/message"
@@ -584,4 +585,9 @@ func AddGRPCInfoToMetadata(
 	metadata[constants.GRPCPortKey] = port
 	metadata[constants.RegionKey] = region
 	return metadata
+}
+
+// Descriptor returns the protobuf message descriptor for a given message name
+func Descriptor(protoName string) ([]byte, error) {
+	return docgenerator.ProtoDescriptors(protoName)
 }

--- a/app_test.go
+++ b/app_test.go
@@ -494,6 +494,16 @@ func TestExtractSpan(t *testing.T) {
 	assert.Equal(t, span.Context(), spanCtx)
 }
 
+func TestDescriptor(t *testing.T) {
+	bts, err := Descriptor("kick.proto")
+	assert.NoError(t, err)
+	assert.NotNil(t, bts)
+
+	bts, err = Descriptor("not_exists.proto")
+	assert.Nil(t, bts)
+	assert.EqualError(t, constants.ErrProtodescriptor, err.Error())
+}
+
 func TestDocumentation(t *testing.T) {
 	doc, err := Documentation(false)
 	assert.NoError(t, err)

--- a/constants/errors.go
+++ b/constants/errors.go
@@ -54,6 +54,7 @@ var (
 	ErrNonsenseRPC                    = errors.New("you are making a rpc that may be processed locally, either specify a different server type or specify a server id")
 	ErrNotifyOnRequest                = errors.New("tried to notify a request route")
 	ErrOnCloseBackend                 = errors.New("onclose callbacks are not allowed on backend servers")
+	ErrProtodescriptor                = errors.New("failed to get protobuf message descriptor")
 	ErrRPCClientNotInitialized        = errors.New("RPC client is not running")
 	ErrRPCLocal                       = errors.New("RPC must be to a different server type")
 	ErrRPCServerNotInitialized        = errors.New("RPC server is not running")

--- a/docgenerator/descriptors.go
+++ b/docgenerator/descriptors.go
@@ -1,0 +1,39 @@
+package docgenerator
+
+import (
+	"reflect"
+	"strings"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/topfreegames/pitaya/constants"
+)
+
+// ProtoDescriptors returns the descriptor for a given message name or .proto file
+func ProtoDescriptors(protoName string) ([]byte, error) {
+	if strings.HasSuffix(protoName, ".proto") {
+		descriptor := proto.FileDescriptor(protoName)
+		if descriptor == nil {
+			return nil, constants.ErrProtodescriptor
+		}
+		return descriptor, nil
+	}
+
+	protoReflectTypePointer := proto.MessageType(protoName)
+
+	if protoReflectTypePointer == nil {
+		return nil, constants.ErrProtodescriptor
+	}
+
+	protoReflectType := protoReflectTypePointer.Elem()
+	protoValue := reflect.New(protoReflectType)
+	descriptorMethod, ok := protoReflectTypePointer.MethodByName("Descriptor")
+
+	if !ok {
+		return nil, constants.ErrProtodescriptor
+	}
+
+	descriptorValue := descriptorMethod.Func.Call([]reflect.Value{protoValue})
+	protoDescriptor := descriptorValue[0].Bytes()
+
+	return protoDescriptor, nil
+}

--- a/docgenerator/descriptors_test.go
+++ b/docgenerator/descriptors_test.go
@@ -1,0 +1,35 @@
+package docgenerator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/topfreegames/pitaya/constants"
+	_ "github.com/topfreegames/pitaya/protos"
+)
+
+func TestProtoDescriptors(t *testing.T) {
+	t.Parallel()
+	tables := []struct {
+		name        string
+		messageName string
+		err         error
+	}{
+		{"fail filename", "not_exists.proto", constants.ErrProtodescriptor},
+		{"success filename", "kick.proto", nil},
+		{"success message", "protos.Push", nil},
+		{"fail message", "protos.DoNotExist", constants.ErrProtodescriptor},
+	}
+	for _, table := range tables {
+		t.Run(table.name, func(t *testing.T) {
+			bts, err := ProtoDescriptors(table.messageName)
+			if table.err != nil {
+				assert.EqualError(t, table.err, err.Error())
+				assert.Nil(t, bts)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, bts)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add a function that returns a protobuf descriptor based on its message name or protobuf filename. This is used by pitaya admin in order to create RPC without prior knowledge about the `protos` that a game uses on its RPC as `input` or `output`.

Descriptors allow us to learn at runtime what fields a message contains and what the types of those fields are. They are registered at compile time, using its source file name `<abc>.proto` and can be retrieved by the same, or by calling the method `Descriptor` on a message.

Its in the same package as the docgenerator because they are related tools - both of them allow other services or APIs (such as pitaya admin) to manage information about pitaya servers. 

The game can use `pitaya.Descriptor(name)` to get the descriptor of a given protobuf message and expose it in a route for pitaya admin.