### PR TITLE
fix report rpc error

### DIFF
--- a/cluster/grpc_rpc_client.go
+++ b/cluster/grpc_rpc_client.go
@@ -126,12 +126,12 @@ func (gs *GRPCClient) Call(ctx context.Context, rpcType protos.RPCType, route *r
 			if res.Error.Code == "" {
 				res.Error.Code = pitErrors.ErrUnknownCode
 			}
-			e := &pitErrors.Error{
+			err = &pitErrors.Error{
 				Code:     res.Error.Code,
 				Message:  res.Error.Msg,
 				Metadata: res.Error.Metadata,
 			}
-			return nil, e
+			return nil, err
 		}
 		return res, nil
 

--- a/cluster/nats_rpc_client.go
+++ b/cluster/nats_rpc_client.go
@@ -190,12 +190,12 @@ func (ns *NatsRPCClient) Call(
 		if res.Error.Code == "" {
 			res.Error.Code = errors.ErrUnknownCode
 		}
-		e := &errors.Error{
+		err = &errors.Error{
 			Code:     res.Error.Code,
 			Message:  res.Error.Msg,
 			Metadata: res.Error.Metadata,
 		}
-		return nil, e
+		return nil, err
 	}
 	return res, nil
 }


### PR DESCRIPTION
When rpc returns an error, it was not reported since the returned error was not used on report