### PR TITLE
Report code on metrics when error

### DIFF
--- a/cluster/grpc_rpc_client.go
+++ b/cluster/grpc_rpc_client.go
@@ -112,8 +112,7 @@ func (gs *GRPCClient) Call(ctx context.Context, rpcType protos.RPCType, route *r
 				startTime := time.Now()
 				ctxT = pcontext.AddToPropagateCtx(ctxT, constants.StartTimeKey, startTime.UnixNano())
 				ctxT = pcontext.AddToPropagateCtx(ctxT, constants.RouteKey, route.String())
-				errored := err != nil
-				metrics.ReportTimingFromCtx(ctx, gs.metricsReporters, "rpc", errored)
+				metrics.ReportTimingFromCtx(ctx, gs.metricsReporters, "rpc", err)
 			}
 			done()
 		}()

--- a/cluster/nats_rpc_client.go
+++ b/cluster/nats_rpc_client.go
@@ -171,8 +171,7 @@ func (ns *NatsRPCClient) Call(
 		ctx = pcontext.AddToPropagateCtx(ctx, constants.RouteKey, route.String())
 		defer func() {
 			typ := "rpc"
-			errored := err != nil
-			metrics.ReportTimingFromCtx(ctx, ns.metricsReporters, typ, errored)
+			metrics.ReportTimingFromCtx(ctx, ns.metricsReporters, typ, err)
 		}()
 	}
 	m, err = ns.conn.Request(getChannel(server.Type, server.ID), marshalledData, ns.reqTimeout)

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -74,3 +74,23 @@ func mergeMetadatas(pitayaErr *Error, metadata map[string]string) {
 		pitayaErr.Metadata[key] = value
 	}
 }
+
+// CodeFromError returns the code of error.
+// If error is nil, return empty string.
+// If error is not a pitaya error, returns unkown code
+func CodeFromError(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	pitayaErr, ok := err.(*Error)
+	if !ok {
+		return ErrUnknownCode
+	}
+
+	if pitayaErr == nil {
+		return ""
+	}
+
+	return pitayaErr.Code
+}

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -106,3 +106,42 @@ func TestErrorError(t *testing.T) {
 	errStr := err.Error()
 	assert.Equal(t, sourceErr.Error(), errStr)
 }
+
+func TestCodeFromError(t *testing.T) {
+	t.Parallel()
+
+	errTest := errors.New("error")
+	codeNotFound := "GAME-404"
+
+	tables := map[string]struct {
+		err  error
+		code string
+	}{
+		"test_not_error": {
+			err:  nil,
+			code: "",
+		},
+
+		"test_not_pitaya_error": {
+			err:  errTest,
+			code: ErrUnknownCode,
+		},
+
+		"test_nil_pitaya_error": {
+			err:  func() *Error { var err *Error; return err }(),
+			code: "",
+		},
+
+		"test_pitaya_error": {
+			err:  NewError(errTest, codeNotFound),
+			code: codeNotFound,
+		},
+	}
+
+	for name, table := range tables {
+		t.Run(name, func(t *testing.T) {
+			code := CodeFromError(table.err)
+			assert.Equal(t, table.code, code)
+		})
+	}
+}

--- a/metrics/prometheus_reporter.go
+++ b/metrics/prometheus_reporter.go
@@ -118,7 +118,7 @@ func (p *PrometheusReporter) registerMetrics(
 			Objectives:  map[float64]float64{0.7: 0.02, 0.95: 0.005, 0.99: 0.001},
 			ConstLabels: constLabels,
 		},
-		append([]string{"route", "status", "type"}, additionalLabelsKeys...),
+		append([]string{"route", "status", "type", "code"}, additionalLabelsKeys...),
 	)
 
 	// ProcessDelay summary

--- a/metrics/report.go
+++ b/metrics/report.go
@@ -26,13 +26,16 @@ import (
 	"time"
 
 	"github.com/topfreegames/pitaya/constants"
+	"github.com/topfreegames/pitaya/errors"
+
 	pcontext "github.com/topfreegames/pitaya/context"
 )
 
 // ReportTimingFromCtx reports the latency from the context
-func ReportTimingFromCtx(ctx context.Context, reporters []Reporter, typ string, errored bool) {
+func ReportTimingFromCtx(ctx context.Context, reporters []Reporter, typ string, err error) {
+	code := errors.CodeFromError(err)
 	status := "ok"
-	if errored {
+	if err != nil {
 		status = "failed"
 	}
 	if len(reporters) > 0 {
@@ -43,6 +46,7 @@ func ReportTimingFromCtx(ctx context.Context, reporters []Reporter, typ string, 
 			"route":  route.(string),
 			"status": status,
 			"type":   typ,
+			"code":   code,
 		})
 		for _, r := range reporters {
 			r.ReportSummary(ResponseTime, tags, float64(elapsed.Nanoseconds()))

--- a/service/handler.go
+++ b/service/handler.go
@@ -318,7 +318,7 @@ func (h *HandlerService) localProcess(ctx context.Context, a *agent.Agent, route
 			a.Session.ResponseMID(ctx, mid, ret)
 		}
 	} else {
-		metrics.ReportTimingFromCtx(ctx, h.metricsReporters, handlerType, false)
+		metrics.ReportTimingFromCtx(ctx, h.metricsReporters, handlerType, nil)
 		tracing.FinishSpan(ctx, err)
 	}
 }


### PR DESCRIPTION
Send code on metrics report when error. This helps filtering errors by using the tag "code". 

Code is reported empty in case of not error. I'm not sure if this is the best thing to do but pitaya doesn't enforce code on responses, only on errors. 

Since the tests will come on next commits, this is a WIP. 