### PR TITLE
Avoid creating two spans for nats rpc server

### DIFF
--- a/cluster/nats_rpc_server.go
+++ b/cluster/nats_rpc_server.go
@@ -203,6 +203,7 @@ func (ns *NatsRPCServer) handleMessages() {
 			maxPending = math.Max(float64(maxPending), subsChanLen)
 			logger.Log.Debugf("subs channel size: %d, max: %d, dropped: %d", subsChanLen, maxPending, dropped)
 			req := &protos.Request{}
+			// TODO: Add tracing here to report delay to start processing message in spans
 			err = proto.Unmarshal(msg.Data, req)
 			if err != nil {
 				// should answer rpc with an error

--- a/service/remote.go
+++ b/service/remote.go
@@ -126,6 +126,7 @@ func (r *RemoteService) AddRemoteBindingListener(bindingListener cluster.RemoteB
 // Call processes a remote call
 func (r *RemoteService) Call(ctx context.Context, req *protos.Request) (*protos.Response, error) {
 	c, err := util.GetContextFromRequest(req, r.server.ID)
+	c = util.StartSpanFromRequest(c, r.server.ID, req.GetMsg().GetRoute())
 	var res *protos.Response
 	if err != nil {
 		res = &protos.Response{


### PR DESCRIPTION
The nats RPC server was creating a tracing span which was not being closed or used