### PR TITLE
Fix possible server startup concurrency

### DIFF
--- a/app.go
+++ b/app.go
@@ -370,17 +370,17 @@ func Start() {
 			app.serviceDiscovery.AddListener(app.rpcClient.(*cluster.GRPCClient))
 		}
 
-		err := RegisterModuleBefore(app.serviceDiscovery, "serviceDiscovery")
-		if err != nil {
-			logger.Log.Fatal("failed to register service discovery module: %s", err.Error())
-		}
-		err = RegisterModuleBefore(app.rpcServer, "rpcServer")
-		if err != nil {
+		if err := RegisterModuleBefore(app.rpcServer, "rpcServer"); err != nil {
 			logger.Log.Fatal("failed to register rpc server module: %s", err.Error())
 		}
-		err = RegisterModuleBefore(app.rpcClient, "rpcClient")
-		if err != nil {
+		if err := RegisterModuleBefore(app.rpcClient, "rpcClient"); err != nil {
 			logger.Log.Fatal("failed to register rpc client module: %s", err.Error())
+		}
+		// set the service discovery as the last module to be started to ensure
+		// all modules have been properly initialized before the server starts
+		// receiving requests from other pitaya servers
+		if err := RegisterModuleAfter(app.serviceDiscovery, "serviceDiscovery"); err != nil {
+			logger.Log.Fatal("failed to register service discovery module: %s", err.Error())
 		}
 
 		app.router.SetServiceDiscovery(app.serviceDiscovery)

--- a/cluster/etcd_service_discovery.go
+++ b/cluster/etcd_service_discovery.go
@@ -209,7 +209,6 @@ func (sd *etcdServiceDiscovery) bootstrapServer(server *Server) error {
 	}
 
 	sd.SyncServers()
-
 	return nil
 }
 
@@ -346,8 +345,7 @@ func (sd *etcdServiceDiscovery) Init() error {
 	sd.cli.Watcher = namespace.NewWatcher(sd.cli.Watcher, sd.etcdPrefix)
 	sd.cli.Lease = namespace.NewLease(sd.cli.Lease, sd.etcdPrefix)
 
-	err = sd.bootstrap()
-	if err != nil {
+	if err = sd.bootstrap(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
The fix is done by initializing the service discovery
module as the last one, ensuring other modules have already
initialized correctly.

Sample of the crash that this commit aims to fix, caused by trying to access the bindingStorage client before it is initialized:

```{"file":"/home/jenkins/golang/pkg/mod/github.com/topfreegames/pitaya@v0.14.6/cluster/grpc_rpc_client.go:298","func":"github.com/topfreegames/pitaya/cluster.(*GRPCClient).getServerHost","level":"info","msg":"server game-rooms-green-eb2e9a0f is in same region or external host not provided, using internal host","server":"metagame","time":"2019-08-23T22:54:45Z"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0xb5c703]

goroutine 1683 [running]:
github.com/topfreegames/pitaya/modules.(*ETCDBindingStorage).GetUserFrontendID(0xc000152420, 0xc00051f0e0, 0x24, 0x11d5eaa, 0x9, 0x0, 0x1d22320, 0xc00203ec00, 0x85cbb5)
	/home/jenkins/golang/pkg/mod/github.com/topfreegames/pitaya@v0.14.6/modules/binding_storage.go:88 +0x103
github.com/topfreegames/pitaya/cluster.(*GRPCClient).SendPush(0xc000132a80, 0xc00051f0e0, 0x24, 0xc001dfbe40, 0xc0017cc300, 0x0, 0x0)
	/home/jenkins/golang/pkg/mod/github.com/topfreegames/pitaya@v0.14.6/cluster/grpc_rpc_client.go:213 +0x22b
github.com/topfreegames/pitaya.SendPushToUsers(0x1203ce1, 0x2a, 0x11807e0, 0xc001d315f0, 0xc00025da30, 0x1, 0x1, 0x11d5eaa, 0x9, 0x0, ...)
	/home/jenkins/golang/pkg/mod/github.com/topfreegames/pitaya@v0.14.6/push.go:60 +0x5a1
git.topfreegames.com/topfreegames/game-pitaya/servers/metagame/handler.sendOnlinePush(0x13b05a0, 0xc0003bed20, 0xc44725d3602227a9, 0xd62961a89305a9bf, 0xc001944620, 0x1, 0x1)
	/home/jenkins/golang/src/git.topfreegames.com/topfreegames/game-pitaya/servers/metagame/handler/friend.go:254 +0x2b6
created by git.topfreegames.com/topfreegames/game-pitaya/servers/metagame/handler.(*Friend).GetRelationships
	/home/jenkins/golang/src/git.topfreegames.com/topfreegames/game-pitaya/servers/metagame/handler/friend.go:235 +0x262
```