### PR TITLE
feat: read bigger messages

### DIFF
--- a/acceptor/ws_acceptor.go
+++ b/acceptor/ws_acceptor.go
@@ -106,8 +106,8 @@ func (w *WSAcceptor) ListenAndServe() {
 	}
 
 	var upgrader = websocket.Upgrader{
-		ReadBufferSize:  1024,
-		WriteBufferSize: 1024,
+		ReadBufferSize:  constants.IOBufferBytesSize,
+		WriteBufferSize: constants.IOBufferBytesSize,
 		CheckOrigin: func(r *http.Request) bool {
 			return true
 		},
@@ -125,8 +125,8 @@ func (w *WSAcceptor) ListenAndServe() {
 // ListenAndServeTLS listens and serve in the specified addr using tls
 func (w *WSAcceptor) ListenAndServeTLS(cert, key string) {
 	var upgrader = websocket.Upgrader{
-		ReadBufferSize:  1024,
-		WriteBufferSize: 1024,
+		ReadBufferSize:  constants.IOBufferBytesSize,
+		WriteBufferSize: constants.IOBufferBytesSize,
 	}
 
 	crt, err := tls.LoadX509KeyPair(cert, key)

--- a/constants/const.go
+++ b/constants/const.go
@@ -99,3 +99,6 @@ const (
 	IPv4         = "ipv4"
 	IPv6         = "ipv6"
 )
+
+// IOBufferBytesSize will be used when reading messages from clients
+var IOBufferBytesSize = 4096

--- a/service/handler.go
+++ b/service/handler.go
@@ -180,7 +180,7 @@ func (h *HandlerService) Handle(conn net.Conn) {
 	}()
 
 	// read loop
-	data := make([]byte, 4096)
+	data := make([]byte, constants.IOBufferBytesSize)
 	buf := bytes.NewBuffer(nil)
 	for {
 		totalLen := 0


### PR DESCRIPTION
We have a limit of 16MB for client messages, however, we had a hard-limit for receiving 2kb data chunks from the clients. This means that any message > 2kb would cause the client to be disconnected. In this commit I make it possible for the server to read chunks that are up-to MaxPacketSize(16mb) in length.