### PR TITLE
Add network metrics to pitaya client

### DIFF
--- a/client/metrics.go
+++ b/client/metrics.go
@@ -1,50 +1,108 @@
 package client
 
-// PingTracker struct used to track ping values
-type PingTracker struct {
-	validPings   int
-	SmoothedPing int64 // Take the average of the two best last ping measurements, ignoring a occasional ping spike
-	lastPings    []int64
-	HighestPing  int64
-	LowestPing   int64
+// Metrics stores client's network metrics, such as
+// pingTracker, to handle ping information; jitter track to handle ping variations and A
+type metrics struct {
+	ping             *pingTracker
+	jitter           *jitterTracker
+	nPacketsSent     int64
+	nPacketsReceived int64
+	nPacketsLost     int64
 }
 
-// NewPingTracker returns a new PingTracker struct
-func NewPingTracker() *PingTracker {
-	return &PingTracker{
-		validPings:   0,
-		SmoothedPing: -1,
-		lastPings:    make([]int64, 3),
-		HighestPing:  -1,
-		LowestPing:   -1,
+// NewMetrics return a new Metrics struct
+func newMetrics() *metrics {
+	return &metrics{
+		ping:             newPingTracker(),
+		jitter:           newJitterTracker(),
+		nPacketsSent:     0,
+		nPacketsReceived: 0,
+		nPacketsLost:     0,
+	}
+}
+
+func (m *metrics) addMeasurement(pingMS int) {
+	m.nPacketsReceived++
+	m.ping.receivedPing(pingMS)
+	jitter := abs(m.ping.lastPings[0] - m.ping.lastPings[1])
+	m.jitter.addSample(jitter)
+}
+
+func (m *metrics) GetCurrentPing() int {
+	return m.ping.smoothedPing
+}
+
+func (m *metrics) GetCurrentJitter() int {
+	if m.jitter.jitterHistogram.nSamples == 0 {
+		return -1
+	}
+	return m.jitter.current
+}
+
+func (m *metrics) GetPingPercentile(percentile float32) int {
+	return m.ping.pingHistogram.getPercentile(percentile)
+}
+
+func (m *metrics) GetJitterPercentile(percentile float32) int {
+	return m.jitter.jitterHistogram.getPercentile(percentile)
+}
+
+func (m *metrics) GetPackagesSent() int64 {
+	return m.nPacketsSent
+}
+
+func (m *metrics) GetPackagesConfirmed() int64 {
+	return m.nPacketsReceived
+}
+
+func (m *metrics) GetPackagesLost() int64 {
+	return m.nPacketsLost
+}
+
+// pingTracker struct used to track ping values
+type pingTracker struct {
+	validPings    int
+	smoothedPing  int // Take the average of the two best last ping measurements, ignoring a occasional ping spike
+	lastPings     []int
+	pingHistogram *percentileGenerator
+}
+
+// newPingTracker returns a new PingTracker struct
+func newPingTracker() *pingTracker {
+	return &pingTracker{
+		validPings:    0,
+		smoothedPing:  -1,
+		lastPings:     make([]int, 3),
+		pingHistogram: newPercentileGenerator(MAX_PERCENTILE_GENERATOR_SAMPLES),
 	}
 }
 
 // ReceivedPing is called when a new ping measurement is received
-func (pt *PingTracker) ReceivedPing(ping int64) {
+func (pt *pingTracker) receivedPing(ping int) {
 	if ping < 0 {
 		return
 	}
 
+	pt.pingHistogram.addSample(ping)
 	pt.lastPings[2] = pt.lastPings[1]
 	pt.lastPings[1] = pt.lastPings[0]
 	pt.lastPings[0] = ping
 
 	maxPing := pt.max()
 	switch pt.validPings {
-	case 3:
-		pt.SmoothedPing = (pt.lastPings[0] + pt.lastPings[2] + pt.lastPings[2] - maxPing) >> 1
 	case 2:
-		pt.SmoothedPing = (pt.lastPings[0] + pt.lastPings[1]) >> 1
-		pt.validPings++
+		pt.smoothedPing = (pt.lastPings[0] + pt.lastPings[1] + pt.lastPings[2] - maxPing) >> 1
 	case 1:
-		pt.SmoothedPing = pt.lastPings[0]
+		pt.smoothedPing = (pt.lastPings[0] + pt.lastPings[1]) >> 1
+		pt.validPings++
+	case 0:
+		pt.smoothedPing = pt.lastPings[0]
 		pt.validPings++
 	}
 }
 
-func (pt *PingTracker) max() int64 {
-	maxPing := int64(-1)
+func (pt *pingTracker) max() int {
+	maxPing := -1
 	for i := 0; i < len(pt.lastPings); i++ {
 		if pt.lastPings[i] > maxPing {
 			maxPing = pt.lastPings[i]
@@ -53,14 +111,31 @@ func (pt *PingTracker) max() int64 {
 	return maxPing
 }
 
-// Metrics stores client's network metrics
-type Metrics struct {
-	Ping *PingTracker
+type jitterTracker struct {
+	current         int
+	highest         int
+	jitterHistogram *percentileGenerator
 }
 
-// NewMetrics return a new Metrics struct
-func NewMetrics() *Metrics {
-	return &Metrics{
-		Ping: NewPingTracker(),
+func newJitterTracker() *jitterTracker {
+	return &jitterTracker{
+		current:         -1,
+		highest:         -1,
+		jitterHistogram: newPercentileGenerator(MAX_PERCENTILE_GENERATOR_SAMPLES),
 	}
+}
+
+func (jt *jitterTracker) addSample(jitterMs int) {
+	if jitterMs > jt.highest {
+		jt.highest = jitterMs
+	}
+	jt.current = jitterMs
+	jt.jitterHistogram.addSample(jitterMs)
+}
+
+func abs(num int) int {
+	if num < 0 {
+		return -num
+	}
+	return num
 }

--- a/client/metrics.go
+++ b/client/metrics.go
@@ -1,0 +1,66 @@
+package client
+
+// PingTracker struct used to track ping values
+type PingTracker struct {
+	validPings   int
+	SmoothedPing int64 // Take the average of the two best last ping measurements, ignoring a occasional ping spike
+	lastPings    []int64
+	HighestPing  int64
+	LowestPing   int64
+}
+
+// NewPingTracker returns a new PingTracker struct
+func NewPingTracker() *PingTracker {
+	return &PingTracker{
+		validPings:   0,
+		SmoothedPing: -1,
+		lastPings:    make([]int64, 3),
+		HighestPing:  -1,
+		LowestPing:   -1,
+	}
+}
+
+// ReceivedPing is called when a new ping measurement is received
+func (pt *PingTracker) ReceivedPing(ping int64) {
+	if ping < 0 {
+		return
+	}
+
+	pt.lastPings[2] = pt.lastPings[1]
+	pt.lastPings[1] = pt.lastPings[0]
+	pt.lastPings[0] = ping
+
+	maxPing := pt.max()
+	switch pt.validPings {
+	case 3:
+		pt.SmoothedPing = (pt.lastPings[0] + pt.lastPings[2] + pt.lastPings[2] - maxPing) >> 1
+	case 2:
+		pt.SmoothedPing = (pt.lastPings[0] + pt.lastPings[1]) >> 1
+		pt.validPings++
+	case 1:
+		pt.SmoothedPing = pt.lastPings[0]
+		pt.validPings++
+	}
+}
+
+func (pt *PingTracker) max() int64 {
+	maxPing := int64(-1)
+	for i := 0; i < len(pt.lastPings); i++ {
+		if pt.lastPings[i] > maxPing {
+			maxPing = pt.lastPings[i]
+		}
+	}
+	return maxPing
+}
+
+// Metrics stores client's network metrics
+type Metrics struct {
+	Ping *PingTracker
+}
+
+// NewMetrics return a new Metrics struct
+func NewMetrics() *Metrics {
+	return &Metrics{
+		Ping: NewPingTracker(),
+	}
+}

--- a/client/metrics_test.go
+++ b/client/metrics_test.go
@@ -1,0 +1,47 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMetrics(t *testing.T) {
+
+	metrics := newMetrics()
+
+	// No mesurements
+	assert.Equal(t, -1, metrics.GetCurrentPing())
+	assert.Equal(t, -1, metrics.GetCurrentJitter())
+
+	metrics.addMeasurement(30)
+	assert.Equal(t, 30, metrics.GetCurrentPing()) // Only ping collected
+	assert.Equal(t, 30, metrics.GetCurrentJitter())
+	assert.Equal(t, int64(1), metrics.GetPackagesConfirmed())
+
+	metrics.addMeasurement(10)
+	assert.Equal(t, 20, metrics.GetCurrentPing()) // Smoothed Ping
+	assert.Equal(t, 20, metrics.GetCurrentJitter())
+	assert.Equal(t, int64(2), metrics.GetPackagesConfirmed())
+
+	metrics.addMeasurement(50)
+	assert.Equal(t, 20, metrics.GetCurrentPing()) // Smoothed Ping
+	assert.Equal(t, 40, metrics.GetCurrentJitter())
+	assert.Equal(t, int64(3), metrics.GetPackagesConfirmed())
+
+	metrics.addMeasurement(100)
+	metrics.addMeasurement(60)
+	assert.Equal(t, 55, metrics.GetCurrentPing())
+	assert.Equal(t, 40, metrics.GetCurrentJitter())
+	assert.Equal(t, int64(5), metrics.GetPackagesConfirmed())
+
+	// Pings so far (sorted): [10, 30, 50, 60, 100]
+	// Jitters so far (sorted): [20, 30, 40, 40, 50]
+	assert.Equal(t, 10, metrics.GetPingPercentile(0))
+	assert.Equal(t, 20, metrics.GetJitterPercentile(0))
+	assert.Equal(t, 50, metrics.GetPingPercentile(0.5))
+	assert.Equal(t, 40, metrics.GetJitterPercentile(0.5))
+	assert.Equal(t, 100, metrics.GetPingPercentile(1))
+	assert.Equal(t, 50, metrics.GetJitterPercentile(1))
+
+}

--- a/client/percentile_generator.go
+++ b/client/percentile_generator.go
@@ -1,0 +1,84 @@
+package client
+
+import (
+	"math/rand"
+	"sort"
+	"time"
+)
+
+const (
+	// MAX_PERCENTILE_GENERATOR_SAMPLES is the max samples that a PercentileGeneretor will store
+	MAX_PERCENTILE_GENERATOR_SAMPLES = 1000
+)
+
+// percentileGenerator is used to collect samples and then get a percentile breakdown of the data.
+// This class can be used even if the number of data points you collect grows
+// beyond the number you want to store in memory, by keeping a random
+// subsample.  Note that if the table is filled and we have to resort
+// to sub-sampling, that the resulting sample will be based on the entire
+// data set you provide.  It will not be biased towards the first or last samples.
+// Source: https://github.com/ValveSoftware/GameNetworkingSockets/blob/f3f9c853d45d9f5aaa98f7eb53d895d514c57f19/src/common/percentile_generator.h
+type percentileGenerator struct {
+	maxSamples    int
+	samples       []int
+	isSorted      bool
+	nSamples      int
+	nTotalSamples uint64
+}
+
+// newPercentileGenerator creates a new PercentileGenerator
+func newPercentileGenerator(maxSamples int) *percentileGenerator {
+	source := rand.NewSource(time.Now().UnixNano())
+	rand.Seed(source.Int63())
+	return &percentileGenerator{
+		maxSamples:    maxSamples,
+		samples:       make([]int, maxSamples),
+		isSorted:      false,
+		nSamples:      0,
+		nTotalSamples: 0,
+	}
+}
+
+// AddSample adds a new sample to PercentileGenerator
+func (pg *percentileGenerator) addSample(sample int) {
+
+	if pg.nSamples < pg.maxSamples {
+		pg.samples[pg.nSamples] = sample
+		pg.nSamples++
+		pg.isSorted = false
+	} else {
+		index := rand.Intn(pg.maxSamples)
+		pg.samples[index] = sample
+		pg.isSorted = false
+	}
+	pg.nTotalSamples++
+}
+
+// GetPercentile returns a estimate of the nth percentile. The percentile should be in the range (0, 1)
+func (pg *percentileGenerator) getPercentile(percentile float32) int {
+	if percentile < 0 || percentile > 1 || pg.nSamples == 0 {
+		return -1
+	}
+
+	if !pg.isSorted {
+		sort.Ints(pg.samples)
+		pg.isSorted = true
+	}
+
+	fltIdx := percentile*float32(pg.nSamples-1) + float32(pg.maxSamples-pg.nSamples)
+	idx := int(fltIdx)
+
+	if idx <= 0 {
+		return pg.samples[0]
+	}
+	if idx >= pg.maxSamples-1 {
+		return pg.samples[pg.maxSamples-1]
+	}
+
+	if fltIdx != float32(idx) && idx+1 < pg.maxSamples {
+		return int((pg.samples[idx] + pg.samples[idx+1]) / 2)
+	}
+
+	return pg.samples[idx]
+
+}

--- a/client/percentile_generator_test.go
+++ b/client/percentile_generator_test.go
@@ -1,0 +1,40 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPercentileGenerator(t *testing.T) {
+	pg := newPercentileGenerator(100)
+
+	var result int
+
+	result = pg.getPercentile(1)
+	assert.Equal(t, result, -1)
+
+	assert.Equal(t, pg.nSamples, 0)
+	assert.Equal(t, pg.nTotalSamples, uint64(0))
+	for i := 1; i <= 100; i++ {
+		pg.addSample(i)
+	}
+
+	assert.Equal(t, pg.nSamples, 100)
+	assert.Equal(t, pg.nTotalSamples, uint64(100))
+
+	result = pg.getPercentile(0.2)
+	assert.Equal(t, result, 20)
+	result = pg.getPercentile(0)
+	assert.Equal(t, result, 1)
+	result = pg.getPercentile(1)
+	assert.Equal(t, result, 100)
+	result = pg.getPercentile(1.1)
+	assert.Equal(t, result, -1)
+	result = pg.getPercentile(-0.1)
+	assert.Equal(t, result, -1)
+
+	pg.addSample(1)
+	assert.Equal(t, pg.nSamples, 100)
+	assert.Equal(t, pg.nTotalSamples, uint64(101))
+}

--- a/client/pitayaclient.go
+++ b/client/pitayaclient.go
@@ -37,4 +37,11 @@ type PitayaClient interface {
 	SendNotify(route string, data []byte) error
 	SendRequest(route string, data []byte) (uint, error)
 	SetClientHandshakeData(data *session.HandshakeData)
+	GetPing() int
+	GetLifetimeConnectionPingPercentile(percentile float32) int
+	GetJitter() int
+	GetLifetimeConnectionJitterPercentile(percentile float32) int
+	GetNumRequestsSent() int64
+	GetNumRequestsConfirmed() int64
+	GetNumRequestsLost() int64
 }

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/jhump/protoreflect v1.5.0
 	github.com/jonboulle/clockwork v0.1.0 // indirect
 	github.com/kr/pretty v0.1.0 // indirect
-	github.com/magiconair/properties v1.8.0 // indirect
+	github.com/magiconair/properties v1.8.0
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/mitchellh/mapstructure v0.0.0-20180715050151-f15292f7a699 // indirect
 	github.com/nats-io/gnatsd v1.4.1


### PR DESCRIPTION
# Network Metrics 

I implemented a struct called Metrics that holds Ping (round trip time), Jitter, and requests information, such as:

## Ping
* Current Ping that is the average of best two pings from the last three collected to avoid some spike
* LifetimePingPercentile to where is possible to get an overview from the lifetime ping measurements in this connection, similar to [this](https://github.com/ValveSoftware/GameNetworkingSockets/blob/f3f9c853d45d9f5aaa98f7eb53d895d514c57f19/src/common/percentile_generator.h).
## Jitter
* Current Jitter, that is the absolute difference from the last two collected pings
* LifetimeJitterPercentile similar to *LifetimePingPercentile*
## Requests
* Num of Requests sent
* Num of Requests acknowledged by the server
* Num of Requests not acknowledged by the server

