### PR TITLE
Fix log print uid fmt string %d -> %s or %v.

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -215,10 +215,10 @@ func (a *Agent) Push(route string, v interface{}) error {
 
 	switch d := v.(type) {
 	case []byte:
-		logger.Log.Debugf("Type=Push, ID=%d, UID=%d, Route=%s, Data=%dbytes",
+		logger.Log.Debugf("Type=Push, ID=%d, UID=%s, Route=%s, Data=%dbytes",
 			a.Session.ID(), a.Session.UID(), route, len(d))
 	default:
-		logger.Log.Debugf("Type=Push, ID=%d, UID=%d, Route=%s, Data=%+v",
+		logger.Log.Debugf("Type=Push, ID=%d, UID=%s, Route=%s, Data=%+v",
 			a.Session.ID(), a.Session.UID(), route, v)
 	}
 	return a.send(pendingMessage{typ: message.Push, route: route, payload: v})
@@ -241,10 +241,10 @@ func (a *Agent) ResponseMID(ctx context.Context, mid uint, v interface{}, isErro
 
 	switch d := v.(type) {
 	case []byte:
-		logger.Log.Debugf("Type=Response, ID=%d, UID=%d, MID=%d, Data=%dbytes",
+		logger.Log.Debugf("Type=Response, ID=%d, UID=%s, MID=%d, Data=%dbytes",
 			a.Session.ID(), a.Session.UID(), mid, len(d))
 	default:
-		logger.Log.Infof("Type=Response, ID=%d, UID=%d, MID=%d, Data=%+v",
+		logger.Log.Infof("Type=Response, ID=%d, UID=%s, MID=%d, Data=%+v",
 			a.Session.ID(), a.Session.UID(), mid, v)
 	}
 
@@ -321,7 +321,7 @@ func (a *Agent) SetStatus(state int32) {
 func (a *Agent) Handle() {
 	defer func() {
 		a.Close()
-		logger.Log.Debugf("Session handle goroutine exit, SessionID=%d, UID=%d", a.Session.ID(), a.Session.UID())
+		logger.Log.Debugf("Session handle goroutine exit, SessionID=%d, UID=%s", a.Session.ID(), a.Session.UID())
 	}()
 
 	go a.write()

--- a/agent/agent_remote.go
+++ b/agent/agent_remote.go
@@ -109,10 +109,10 @@ func (a *Remote) Push(route string, v interface{}) error {
 	}
 	switch d := v.(type) {
 	case []byte:
-		logger.Log.Debugf("Type=Push, ID=%d, UID=%d, Route=%s, Data=%dbytes",
+		logger.Log.Debugf("Type=Push, ID=%d, UID=%s, Route=%s, Data=%dbytes",
 			a.Session.ID(), a.Session.UID(), route, len(d))
 	default:
-		logger.Log.Debugf("Type=Push, ID=%d, UID=%d, Route=%s, Data=%+v",
+		logger.Log.Debugf("Type=Push, ID=%d, UID=%s, Route=%s, Data=%+v",
 			a.Session.ID(), a.Session.UID(), route, v)
 	}
 

--- a/group.go
+++ b/group.go
@@ -74,7 +74,7 @@ func GroupBroadcast(ctx context.Context, frontendType, groupName, route string, 
 func sendDataToMembers(uids []string, frontendType, route string, v interface{}) error {
 	errUids, err := SendPushToUsers(route, v, uids, frontendType)
 	if err != nil {
-		logger.Log.Errorf("Group push message error, UID=%d, Error=%s", errUids, err.Error())
+		logger.Log.Errorf("Group push message error, UID=%v, Error=%s", errUids, err.Error())
 		return err
 	}
 	return nil
@@ -93,13 +93,13 @@ func GroupAddMember(ctx context.Context, groupName, uid string) error {
 	if uid == "" {
 		return constants.ErrEmptyUID
 	}
-	logger.Log.Debugf("Add user to group %s, UID=%d", groupName, uid)
+	logger.Log.Debugf("Add user to group %s, UID=%s", groupName, uid)
 	return groupServiceInstance.GroupAddMember(ctx, groupName, uid)
 }
 
 // GroupRemoveMember removes specified UID from group
 func GroupRemoveMember(ctx context.Context, groupName, uid string) error {
-	logger.Log.Debugf("Remove user from group %s, UID=%d", groupName, uid)
+	logger.Log.Debugf("Remove user from group %s, UID=%s", groupName, uid)
 	return groupServiceInstance.GroupRemoveMember(ctx, groupName, uid)
 }
 

--- a/kick.go
+++ b/kick.go
@@ -41,13 +41,13 @@ func SendKickToUsers(uids []string, frontendType string) ([]string, error) {
 		if s := session.GetSessionByUID(uid); s != nil {
 			if err := s.Kick(context.Background()); err != nil {
 				notKickedUids = append(notKickedUids, uid)
-				logger.Log.Errorf("Session kick error, ID=%d, UID=%d, ERROR=%s", s.ID(), s.UID(), err.Error())
+				logger.Log.Errorf("Session kick error, ID=%d, UID=%s, ERROR=%s", s.ID(), s.UID(), err.Error())
 			}
 		} else if app.rpcClient != nil {
 			kick := &protos.KickMsg{UserId: uid}
 			if err := app.rpcClient.SendKick(uid, frontendType, kick); err != nil {
 				notKickedUids = append(notKickedUids, uid)
-				logger.Log.Errorf("RPCClient send kick error, UID=%d, SvType=%s, Error=%s", uid, frontendType, err.Error())
+				logger.Log.Errorf("RPCClient send kick error, UID=%s, SvType=%s, Error=%s", uid, frontendType, err.Error())
 			}
 		} else {
 			notKickedUids = append(notKickedUids, uid)

--- a/push.go
+++ b/push.go
@@ -48,7 +48,7 @@ func SendPushToUsers(route string, v interface{}, uids []string, frontendType st
 		if s := session.GetSessionByUID(uid); s != nil && app.server.Type == frontendType {
 			if err := s.Push(route, data); err != nil {
 				notPushedUids = append(notPushedUids, uid)
-				logger.Log.Errorf("Session push message error, ID=%d, UID=%d, Error=%s",
+				logger.Log.Errorf("Session push message error, ID=%d, UID=%s, Error=%s",
 					s.ID(), s.UID(), err.Error())
 			}
 		} else if app.rpcClient != nil {

--- a/service/handler.go
+++ b/service/handler.go
@@ -176,7 +176,7 @@ func (h *HandlerService) Handle(conn acceptor.PlayerConn) {
 	// guarantee agent related resource is destroyed
 	defer func() {
 		a.Session.Close()
-		logger.Log.Debugf("Session read goroutine exit, SessionID=%d, UID=%d", a.Session.ID(), a.Session.UID())
+		logger.Log.Debugf("Session read goroutine exit, SessionID=%d, UID=%s", a.Session.ID(), a.Session.UID())
 	}()
 
 	for {


### PR DESCRIPTION
After run `make run-cluster-grpc-example-connector`, I see the log output below:

```
DEBU[9360] type: room, servers: map[fe10d5d3-7dde-4a06-b0d1-e1a51bcc7ea3:0xc0002ee240]  source=pitaya
ERRO[9435] Failed to process remote: session is already bound to an uid  source=pitaya
DEBU[9435] Type=Response, ID=4, UID=%!d(string=1), MID=2, Data=89bytes  source=pitaya
ERRO[9452] Failed to process remote: session is already bound to an uid  source=pitaya
DEBU[9452] Type=Response, ID=4, UID=%!d(string=1), MID=3, Data=89bytes  source=pitaya
```

It seems that we're using wrong format string for printing uid, so I proposed this PR for fixing this.
