### PR TITLE
Reduce connection close error logs

### DIFF
--- a/acceptor/tcp_acceptor.go
+++ b/acceptor/tcp_acceptor.go
@@ -51,6 +51,10 @@ func (t *tcpPlayerConn) GetNextMessage() (b []byte, err error) {
 	if err != nil {
 		return nil, err
 	}
+	// if the header has no data, we can consider it as a closed connection
+	if len(header) == 0 {
+		return nil, constants.ErrConnectionClosed
+	}
 	msgSize, _, err := codec.ParseHeader(header)
 	if err != nil {
 		return nil, err

--- a/constants/errors.go
+++ b/constants/errors.go
@@ -84,4 +84,5 @@ var (
 	ErrRateLimitExceeded              = errors.New("rate limit exceeded")
 	ErrReceivedMsgSmallerThanExpected = errors.New("received less data than expected, EOF?")
 	ErrReceivedMsgBiggerThanExpected  = errors.New("received more data than expected")
+	ErrConnectionClosed               = errors.New("client connection closed")
 )

--- a/service/handler.go
+++ b/service/handler.go
@@ -183,7 +183,10 @@ func (h *HandlerService) Handle(conn acceptor.PlayerConn) {
 		msg, err := conn.GetNextMessage()
 
 		if err != nil {
-			logger.Log.Errorf("Error reading next available message: %s", err.Error())
+			if err != constants.ErrConnectionClosed {
+				logger.Log.Errorf("Error reading next available message: %s", err.Error())
+			}
+
 			return
 		}
 


### PR DESCRIPTION
When a connection closes without any message left, there is always a log that appears. This happens not even when the connection is established and closed, but in all connections being closed. This has shown to be a very annoying log (sometimes entire slots of logs are just composed by this message) and does not fully represent the error and can be misleading.

`{"component":"pitaya","level":"error","msg":"Error reading next available message: invalid header","time":"2020-12-09T21:21:25Z"}`

The idea here is to treat a connection close differently from, for example, a header with an invalid format or an incomplete message. By doing this, we are able to not log an error when it happens and reduce the noise generated in the logs.