### PR TITLE
Add more information to nats timeout error logs

### DIFF
--- a/cluster/etcd_service_discovery.go
+++ b/cluster/etcd_service_discovery.go
@@ -590,7 +590,13 @@ func (sd *etcdServiceDiscovery) watchEtcdChanges() {
 	go func(chn clientv3.WatchChan) {
 		for sd.running {
 			select {
-			case wResp := <-chn:
+			case wResp, ok := <-chn:
+				if wResp.Err() != nil {
+					logger.Log.Warnf("etcd watcher response error: %s", wResp.Err())
+				}
+				if !ok {
+					logger.Log.Error("etcd watcher died")
+				}
 				for _, ev := range wResp.Events {
 					svType, svID, err := parseEtcdKey(string(ev.Kv.Key))
 					if err != nil {

--- a/service/remote.go
+++ b/service/remote.go
@@ -98,13 +98,13 @@ func (r *RemoteService) remoteProcess(
 	switch msg.Type {
 	case message.Request:
 		if err != nil {
-			logger.Log.Errorf("Failed to process remote server with id '%s' and hostname '%s': %s", server.ID, server.Hostname, err.Error())
+			logger.Log.Errorf("Failed to process remote server with id %s and hostname %s: %s", server.ID, server.Hostname, err.Error())
 			a.AnswerWithError(ctx, msg.ID, err)
 			return
 		}
 		err := a.Session.ResponseMID(ctx, msg.ID, res.Data)
 		if err != nil {
-			logger.Log.Errorf("Failed to respond to remote server with id '%s' and hostname '%s': %s", server.ID, server.Hostname, err.Error())
+			logger.Log.Errorf("Failed to respond to remote server with id %s and hostname %s: %s", server.ID, server.Hostname, err.Error())
 			a.AnswerWithError(ctx, msg.ID, err)
 		}
 	case message.Notify:
@@ -113,7 +113,7 @@ func (r *RemoteService) remoteProcess(
 			err = errors.New(res.Error.GetMsg())
 		}
 		if err != nil {
-			logger.Log.Errorf("error while sending a notify to server with id '%s' and hostname '%s': %s", server.ID, server.Hostname, err.Error())
+			logger.Log.Errorf("error while sending a notify to server with id %s and hostname %s: %s", server.ID, server.Hostname, err.Error())
 		}
 	}
 }

--- a/service/remote.go
+++ b/service/remote.go
@@ -98,13 +98,13 @@ func (r *RemoteService) remoteProcess(
 	switch msg.Type {
 	case message.Request:
 		if err != nil {
-			logger.Log.Errorf("Failed to process remote: %s", err.Error())
+			logger.Log.Errorf("Failed to process remote server with id '%s' and hostname '%s': %s", server.ID, server.Hostname, err.Error())
 			a.AnswerWithError(ctx, msg.ID, err)
 			return
 		}
 		err := a.Session.ResponseMID(ctx, msg.ID, res.Data)
 		if err != nil {
-			logger.Log.Errorf("Failed to respond remote: %s", err.Error())
+			logger.Log.Errorf("Failed to respond to remote server with id '%s' and hostname '%s': %s", server.ID, server.Hostname, err.Error())
 			a.AnswerWithError(ctx, msg.ID, err)
 		}
 	case message.Notify:
@@ -113,7 +113,7 @@ func (r *RemoteService) remoteProcess(
 			err = errors.New(res.Error.GetMsg())
 		}
 		if err != nil {
-			logger.Log.Errorf("error while sending a notify: %s", err.Error())
+			logger.Log.Errorf("error while sending a notify to server with id '%s' and hostname '%s': %s", server.ID, server.Hostname, err.Error())
 		}
 	}
 }


### PR DESCRIPTION
We are having a lot of problems with `nats timeout` in our clusters. We have some theories of what it might be but we need more information to make sure we are attacking the right problem. This commit adds more information to `nats timeout` logs and also add logs in case anything happens with the etcd watcher.