### PR TITLE
Migrate from Travis CI to Github Actions

### DIFF
--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -16,17 +16,17 @@ jobs:
         go-version: '1.13'
     - name: Checkout
       uses: actions/checkout@v2
-    - name: Restore cache
-      uses: actions/cache@v2
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-    - name: Setup dependencies
-      run: make setup-ci
-    - name: Run tests
-      run: make test
+    # - name: Restore cache
+    #   uses: actions/cache@v2
+    #   with:
+    #     path: ~/go/pkg/mod
+    #     key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+    #     restore-keys: |
+    #       ${{ runner.os }}-go-
+    # - name: Setup dependencies
+    #   run: make setup-ci
+    # - name: Run tests
+    #   run: make test
     - name: Install goveralls
       env:
         GO111MODULE: off
@@ -34,4 +34,4 @@ jobs:
     - name: Send coverage
       env:
         COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: goveralls -coverprofile=covprofile -service=github
+      run: $GOPATH/bin/goveralls -coverprofile=covprofile -service=github

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -34,4 +34,4 @@ jobs:
     - name: Send coverage
       env:
         COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: $GOPATH/bin/goveralls -coverprofile=covprofile -service=github
+      run: ~/go/bin/goveralls -coverprofile=covprofile -service=github

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -16,17 +16,17 @@ jobs:
         go-version: '1.13'
     - name: Checkout
       uses: actions/checkout@v2
-    # - name: Restore cache
-    #   uses: actions/cache@v2
-    #   with:
-    #     path: ~/go/pkg/mod
-    #     key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-    #     restore-keys: |
-    #       ${{ runner.os }}-go-
-    # - name: Setup dependencies
-    #   run: make setup-ci
-    # - name: Run tests
-    #   run: make test
+    - name: Restore cache
+      uses: actions/cache@v2
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - name: Setup dependencies
+      run: make setup-ci
+    - name: Run tests
+      run: make test
     - name: Install goveralls
       env:
         GO111MODULE: off

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -20,3 +20,7 @@ jobs:
       run: make setup-ci
     - name: Run tests
       run: make test
+    - name: Send coverage
+      env:
+        COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: goveralls -coverprofile=covprofile -service=github

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -1,7 +1,7 @@
 name: Quality
 
 on:
-  push:
+  pull_request:
     branches:
     - master
 

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -6,8 +6,8 @@ on:
     - master
 
 jobs:
-  test:
-    name: Test
+  deps:
+    name: Dependencies
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go
@@ -23,15 +23,73 @@ jobs:
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
+    - name: Download dependencies
+      run: go mod download
+  unit-test:
+    name: Unit Test
+    runs-on: ubuntu-latest
+    needs: deps
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: '1.13'
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Restore cache
+      uses: actions/cache@v2
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
     - name: Setup dependencies
-      run: make setup-ci
-    - name: Run tests
-      run: make test
-    - name: Install goveralls
       env:
         GO111MODULE: off
-      run: go get github.com/mattn/goveralls
+      run: make setup-ci
+    - name: Run tests
+      run: make test-coverage
     - name: Send coverage
       env:
         COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: ~/go/bin/goveralls -coverprofile=coverprofile.out -service=github
+  e2e-test-nats:
+    name: Nats Test End to End
+    runs-on: ubuntu-latest
+    needs: deps
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: '1.13'
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Restore cache
+      uses: actions/cache@v2
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - name: Run tests
+      run: make e2e-test-nats
+  e2e-test-grpc:
+    name: GRPC Test End to End
+    runs-on: ubuntu-latest
+    needs: deps
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: '1.13'
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Restore cache
+      uses: actions/cache@v2
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - name: Run tests
+      run: make e2e-test-grpc

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -16,7 +16,16 @@ jobs:
         go-version: '1.13'
     - name: Checkout
       uses: actions/checkout@v2
+    - name: Restore cache
+      uses: actions/cache@v2
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
     - name: Setup dependencies
+      env:
+        GO111MODULE: off
       run: make setup-ci
     - name: Run tests
       run: make test

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -34,4 +34,4 @@ jobs:
     - name: Send coverage
       env:
         COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: ~/go/bin/goveralls -coverprofile=covprofile -service=github
+      run: ~/go/bin/goveralls -coverprofile=coverprofile.out -service=github

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -1,0 +1,22 @@
+name: Quality
+
+on:
+  push:
+    branches:
+    - master
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: '1.13'
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Setup dependencies
+      run: make setup-ci
+    - name: Run tests
+      run: make test

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -24,11 +24,13 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-
     - name: Setup dependencies
-      env:
-        GO111MODULE: off
       run: make setup-ci
     - name: Run tests
       run: make test
+    - name: Install goveralls
+      env:
+        GO111MODULE: off
+      run: go get github.com/mattn/goveralls
     - name: Send coverage
       env:
         COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: go
-go:
-- "1.13"
-sudo: false
-services:
-- docker
-before_script: make setup-ci
-script: make test
-after_success: $HOME/gopath/bin/goveralls -coverprofile coverprofile.out -service=travis-ci


### PR DESCRIPTION
This PR creates a Github Actions workflow for the pitaya project so we can move away from Travis. Sometimes we have to face long queues when waiting for the CI to run in travis and it's really painful to have any feedback from the CI.