### PR TITLE
Add `IsRunning` function to the `pitaya.Pitaya`

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,10 +3,10 @@ name: Tests
 on:
   push:
     branches:
-    - master
+    - v2
   pull_request:
     branches:
-    - master
+    - v2
 
 jobs:
   deps:

--- a/app.go
+++ b/app.go
@@ -87,6 +87,7 @@ type Pitaya interface {
 	StartWorker()
 	RegisterRPCJob(rpcJob worker.RPCJob) error
 	Documentation(getPtrNames bool) (map[string]interface{}, error)
+	IsRunning() bool
 
 	RPC(ctx context.Context, routeStr string, reply proto.Message, arg proto.Message) error
 	RPCTo(ctx context.Context, serverID, routeStr string, reply proto.Message, arg proto.Message) error
@@ -250,6 +251,13 @@ func (app *App) GetServersByType(t string) (map[string]*cluster.Server, error) {
 // GetServers get all servers
 func (app *App) GetServers() []*cluster.Server {
 	return app.serviceDiscovery.GetServers()
+}
+
+// IsRunning indicates if the Pitaya app has been initialized. Note: This
+// doesn't cover acceptors, only the pitaya internal registration and modules
+// initialization.
+func (app *App) IsRunning() bool {
+	return app.running
 }
 
 // SetLogger logger setter

--- a/mocks/app.go
+++ b/mocks/app.go
@@ -358,6 +358,20 @@ func (mr *MockPitayaMockRecorder) GroupRenewTTL(arg0, arg1 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GroupRenewTTL", reflect.TypeOf((*MockPitaya)(nil).GroupRenewTTL), arg0, arg1)
 }
 
+// IsRunning mocks base method
+func (m *MockPitaya) IsRunning() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsRunning")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsRunning indicates an expected call of IsRunning
+func (mr *MockPitayaMockRecorder) IsRunning() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsRunning", reflect.TypeOf((*MockPitaya)(nil).IsRunning))
+}
+
 // RPC mocks base method
 func (m *MockPitaya) RPC(arg0 context.Context, arg1 string, arg2, arg3 proto.Message) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
This function exposes the `running` property. This property indicates whether the application is running. We can assume `running = true` when:
* Listeners started (but it doesn't guarantee that they are ready to accept connections);
* All components were registered;
* All modules were registered;

This will help during tests to identify if the server is ready to receive requests.

**Plus: This PR fixes the branch name on the Github Actions configuration.**