### PR TITLE
Add `jsonpb` serializer

### DIFF
--- a/serialize/jsonpb/jsonpb.go
+++ b/serialize/jsonpb/jsonpb.go
@@ -1,0 +1,57 @@
+package jsonpb
+
+import (
+	"github.com/golang/protobuf/jsonpb"
+	"github.com/golang/protobuf/proto"
+	"github.com/topfreegames/pitaya/v2/constants"
+)
+
+// Serializer implements the serialize.Serializer interface
+type Serializer struct {
+	marshaler *jsonpb.Marshaler
+}
+
+// NewSerializer returns a new Serializer.
+func NewSerializer() *Serializer {
+	return &Serializer{
+		marshaler: &jsonpb.Marshaler{EnumsAsInts: true},
+	}
+}
+
+// Marshal returns the JSON encoding of v.
+func (s *Serializer) Marshal(v interface{}) ([]byte, error) {
+	pb, ok := v.(proto.Message)
+	if !ok {
+		return []byte{}, constants.ErrWrongValueType
+	}
+
+	res, err := s.marshaler.MarshalToString(pb)
+	if err != nil {
+		return []byte{}, constants.ErrWrongValueType
+	}
+
+	return []byte(res), nil
+}
+
+// Unmarshal parses the JSON-encoded data and stores the result
+// in the value pointed to by v.
+func (s *Serializer) Unmarshal(data []byte, v interface{}) error {
+	pb, ok := v.(proto.Message)
+	if !ok {
+		return constants.ErrWrongValueType
+	}
+
+	err := jsonpb.UnmarshalString(string(data), pb)
+	if err != nil {
+		return constants.ErrWrongValueType
+	}
+
+	return nil
+}
+
+// GetName returns the name of the serializer.
+func (s *Serializer) GetName() string {
+	// NOTE: this serializer doesn't use a different name than `json` because it
+	// must behave exactly the same as `json` on the client side.
+	return "json"
+}

--- a/serialize/jsonpb/jsonpb_test.go
+++ b/serialize/jsonpb/jsonpb_test.go
@@ -1,0 +1,73 @@
+package jsonpb
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/topfreegames/pitaya/v2/constants"
+	"github.com/topfreegames/pitaya/v2/protos"
+	"github.com/topfreegames/pitaya/v2/serialize/json"
+)
+
+func TestMarshal(t *testing.T) {
+	type JSONStruct struct {
+		FieldA string `json:"field_a"`
+	}
+
+	tests := map[string]struct {
+		raw     interface{}
+		errType interface{}
+	}{
+		"ValidProtobufMessageSuccessMarshal": {&protos.Request{Type: protos.RPCType_User, FrontendID: "abc"}, nil},
+		"ValidJSONStructFailsMarshal":        {JSONStruct{FieldA: "test"}, constants.ErrWrongValueType},
+		"InvalidProtobufMessageFailsMarshal": {"invalid", constants.ErrWrongValueType},
+	}
+
+	serializer := NewSerializer()
+	jsonSerializer := json.NewSerializer()
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			res, err := serializer.Marshal(test.raw)
+			assert.Equal(t, test.errType, err)
+
+			if test.errType == nil {
+				jsonRes, jsonErr := jsonSerializer.Marshal(test.raw)
+				assert.NoError(t, jsonErr)
+
+				// remove spaces
+				bytes.ReplaceAll(jsonRes, []byte(" "), []byte{})
+				bytes.ReplaceAll(res, []byte(" "), []byte{})
+				assert.Equal(t, jsonRes, res)
+			}
+		})
+	}
+}
+
+func TestUnmarshal(t *testing.T) {
+	type JSONStruct struct {
+		FieldA string `json:"field_a"`
+	}
+
+	tests := map[string]struct {
+		expected  proto.Message
+		dest      proto.Message
+		marshaled []byte
+		errType   interface{}
+	}{
+		"ValidJSONMessageSuccessUnmarshal": {&protos.Request{Type: protos.RPCType_User, FrontendID: "abc", Metadata: []byte{}}, &protos.Request{}, []byte("{\"type\":1,\"frontendID\":\"abc\"}"), nil},
+		"InvalidMessageFailsMarshal":       {nil, &protos.Request{}, []byte(""), constants.ErrWrongValueType},
+	}
+
+	serializer := NewSerializer()
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := serializer.Unmarshal(test.marshaled, test.dest)
+			assert.Equal(t, test.errType, err)
+			if test.errType == nil {
+				assert.True(t, proto.Equal(test.expected, test.dest))
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds a new serializer to Pitaya v2. This serializer is intended to produce and parse the same data as the `JSON` serializer (from the client's perspective). The main difference is that it will take `protobuf.Message` struct to marshal/unmarshal data.

Its addition takes advantage of the Protobuf messages to be converted to JSON. It enables applications to rely on Protobuf messages to define their handlers contracts (input and output) and still supporting JSON for the client's usage.