### PR TITLE
conn/message: add mutex to routes/codes maps

### DIFF
--- a/conn/message/message.go
+++ b/conn/message/message.go
@@ -139,7 +139,11 @@ func SetDictionary(dict map[string]uint16) error {
 func GetDictionary() map[string]uint16 {
 	routesCodesMutex.RLock()
 	defer routesCodesMutex.RUnlock()
-	return routes
+	dict := make(map[string]uint16)
+	for k, v := range routes {
+		dict[k] = v
+	}
+	return dict
 }
 
 func (t *Type) String() string {

--- a/conn/message/message.go
+++ b/conn/message/message.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 )
 
 // Type represents the type of message, which could be Request/Notify/Response/Push
@@ -54,8 +55,9 @@ var types = map[Type]string{
 }
 
 var (
-	routes = make(map[string]uint16) // route map to code
-	codes  = make(map[uint16]string) // code map to route
+	routesCodesMutex = sync.RWMutex{}
+	routes           = make(map[string]uint16) // route map to code
+	codes            = make(map[uint16]string) // code map to route
 )
 
 // Errors that could be occurred in message codec
@@ -110,6 +112,8 @@ func SetDictionary(dict map[string]uint16) error {
 	if dict == nil {
 		return nil
 	}
+	routesCodesMutex.Lock()
+	defer routesCodesMutex.Unlock()
 
 	for route, code := range dict {
 		r := strings.TrimSpace(route)
@@ -133,6 +137,8 @@ func SetDictionary(dict map[string]uint16) error {
 
 // GetDictionary gets the routes map which is used to compress route.
 func GetDictionary() map[string]uint16 {
+	routesCodesMutex.RLock()
+	defer routesCodesMutex.RUnlock()
 	return routes
 }
 

--- a/conn/message/message_encoder.go
+++ b/conn/message/message_encoder.go
@@ -69,7 +69,9 @@ func (me *MessagesEncoder) Encode(message *Message) ([]byte, error) {
 	buf := make([]byte, 0)
 	flag := byte(message.Type) << 1
 
+	routesCodesMutex.RLock()
 	code, compressed := routes[message.Route]
+	routesCodesMutex.RUnlock()
 	if compressed {
 		flag |= msgRouteCompressMask
 	}
@@ -163,7 +165,9 @@ func Decode(data []byte) (*Message, error) {
 		if flag&msgRouteCompressMask == 1 {
 			m.compressed = true
 			code := binary.BigEndian.Uint16(data[offset:(offset + 2)])
+			routesCodesMutex.RLock()
 			route, ok := codes[code]
+			routesCodesMutex.RUnlock()
 			if !ok {
 				return nil, ErrRouteInfoNotFound
 			}

--- a/conn/message/message_test.go
+++ b/conn/message/message_test.go
@@ -14,6 +14,8 @@ var update = flag.Bool("update", false, "update .golden files")
 
 func resetDicts(t *testing.T) {
 	t.Helper()
+	routesCodesMutex.Lock()
+	defer routesCodesMutex.Unlock()
 	routes = make(map[string]uint16)
 	codes = make(map[uint16]string)
 }
@@ -156,7 +158,7 @@ var dictTables = map[string]struct {
 		map[uint16]string{1: "a"}, errors.New("duplicated route(route: b, code: 1)")},
 }
 
-func TestSetDictionaty(t *testing.T) {
+func TestSetDictionary(t *testing.T) {
 	for name, table := range dictTables {
 		t.Run(name, func(t *testing.T) {
 			for _, dict := range table.dicts {
@@ -169,4 +171,28 @@ func TestSetDictionaty(t *testing.T) {
 			resetDicts(t)
 		})
 	}
+}
+
+func TestSetDictionaryRace(t *testing.T) {
+	defer resetDicts(t)
+
+	done := make(chan bool, 2)
+
+	setDictRace := func(dict map[string]uint16) {
+		assert.Nil(t, SetDictionary(dict))
+		done <- true
+	}
+
+	go setDictRace(map[string]uint16{"a": 1})
+	go setDictRace(map[string]uint16{"b": 2})
+
+	// wait for both setDictRace to finish
+	<-done
+	<-done
+
+	expected_codes := map[uint16]string{1: "a", 2: "b"}
+	assert.EqualValues(t, expected_codes, codes)
+
+	expected_routes := map[string]uint16{"a": 1, "b": 2}
+	assert.EqualValues(t, expected_routes, routes)
 }

--- a/conn/message/message_test.go
+++ b/conn/message/message_test.go
@@ -3,6 +3,7 @@ package message
 import (
 	"errors"
 	"flag"
+	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -195,4 +196,16 @@ func TestSetDictionaryRace(t *testing.T) {
 
 	expected_routes := map[string]uint16{"a": 1, "b": 2}
 	assert.EqualValues(t, expected_routes, routes)
+}
+
+func TestGetDictionary(t *testing.T) {
+	defer resetDicts(t)
+	expected := map[string]uint16{"a": 1, "b": 2}
+	assert.Nil(t, SetDictionary(expected))
+
+	dict := GetDictionary()
+	assert.Equal(t, expected, dict)
+
+	// make sure we're copying the routes maps
+	assert.NotEqual(t, fmt.Sprintf("%p", routes), fmt.Sprintf("%p", dict))
 }


### PR DESCRIPTION
When running in high concurrency scenarios the routes/codes maps may be updated by concurrent goroutines at the same time, resulting in a race condition while calling `message.SetDictionary`. This patch adds a mutex to control access to these maps.

I decided to add the read lock to `message.GetDictionary` but this may not have the desired effect, since `map`s act as pointers [1] to its internal structures and the reference to the `routes` map is what is getting returned from the function. So, if `message.GetDictionary` callers decide to change the data in it, it may lead into another race. Ideally we would be copying the values into a new map and returning the copy. Since I'm new to the codebase I'm not sure how big this data structure can get and if this will lead into reliability issues. Should I add the map copy in there? I only found a reference to `message.GetDictionary` on `agent/agent.go:469`, where it gets serialized to JSON right after.

The new test must be called with the race detector enabled for proper validation, e.g. `go test -race ./conn/message`, however enabling it by default may result in breaking more tests than this PR is scoped to, so I decide to not enable it in the `Makefile`.

#### before the mutex addition:

```
% go test -race ./conn/message
==================
WARNING: DATA RACE
Read at 0x00c000260cf0 by goroutine 16:
  runtime.mapaccess2_faststr()
      /home/rochacon/sdk/go1.16.3/src/runtime/map_faststr.go:107 +0x0
  github.com/topfreegames/pitaya/conn/message.SetDictionary()
      /home/rochacon/src/github.com/topfreegames/pitaya/conn/message/message.go:120 +0x184
  github.com/topfreegames/pitaya/conn/message.TestSetDictionaryRace.func1()
      /home/rochacon/src/github.com/topfreegames/pitaya/conn/message/message_test.go:182 +0x107

Previous write at 0x00c000260cf0 by goroutine 15:
  runtime.mapassign_faststr()
      /home/rochacon/sdk/go1.16.3/src/runtime/map_faststr.go:202 +0x0
  github.com/topfreegames/pitaya/conn/message.SetDictionary()
      /home/rochacon/src/github.com/topfreegames/pitaya/conn/message/message.go:129 +0x21a
  github.com/topfreegames/pitaya/conn/message.TestSetDictionaryRace.func1()
      /home/rochacon/src/github.com/topfreegames/pitaya/conn/message/message_test.go:182 +0x107

Goroutine 16 (running) created at:
  github.com/topfreegames/pitaya/conn/message.TestSetDictionaryRace()
      /home/rochacon/src/github.com/topfreegames/pitaya/conn/message/message_test.go:187 +0x13d
  testing.tRunner()
      /home/rochacon/sdk/go1.16.3/src/testing/testing.go:1193 +0x202

Goroutine 15 (finished) created at:
  github.com/topfreegames/pitaya/conn/message.TestSetDictionaryRace()
      /home/rochacon/src/github.com/topfreegames/pitaya/conn/message/message_test.go:186 +0x124
  testing.tRunner()
      /home/rochacon/sdk/go1.16.3/src/testing/testing.go:1193 +0x202
==================
--- FAIL: TestSetDictionaryRace (0.00s)
    testing.go:1092: race detected during execution of test
FAIL
FAIL    github.com/topfreegames/pitaya/conn/message     0.062s
FAIL
```

#### after

```
% go test -race ./conn/message
ok      github.com/topfreegames/pitaya/conn/message  
```

Fixes #166 


[1] https://play.golang.org/p/FKW0RnPO8J6
