### PR TITLE
Fix initialisation

### DIFF
--- a/cluster/etcd_service_discovery.go
+++ b/cluster/etcd_service_discovery.go
@@ -651,7 +651,7 @@ func (sd *etcdServiceDiscovery) watchEtcdChanges() {
 			case wResp, ok := <-chn:
 				if wResp.Err() != nil {
 					logger.Log.Warnf("etcd watcher response error: %s", wResp.Err())
-					time.Sleep(100 * time.Millisecond)
+					time.Sleep(10 * time.Millisecond)
 				}
 				if !ok {
 					logger.Log.Error("etcd watcher died, retrying to watch in 1 second")

--- a/cluster/etcd_service_discovery.go
+++ b/cluster/etcd_service_discovery.go
@@ -650,7 +650,7 @@ func (sd *etcdServiceDiscovery) watchEtcdChanges() {
 			case wResp, ok := <-chn:
 				if wResp.Err() != nil {
 					logger.Log.Warnf("etcd watcher response error: %s", wResp.Err())
-					time.Sleep(10 * time.Millisecond)
+					time.Sleep(100 * time.Millisecond)
 				}
 				if !ok {
 					logger.Log.Error("etcd watcher died, retrying to watch in 1 second")

--- a/cluster/etcd_service_discovery.go
+++ b/cluster/etcd_service_discovery.go
@@ -379,6 +379,7 @@ func (sd *etcdServiceDiscovery) Init() error {
 		sd.cli.Watcher = namespace.NewWatcher(sd.cli.Watcher, sd.etcdPrefix)
 		sd.cli.Lease = namespace.NewLease(sd.cli.Lease, sd.etcdPrefix)
 	}
+	go sd.watchEtcdChanges()
 
 	if err = sd.bootstrap(); err != nil {
 		return err
@@ -400,7 +401,6 @@ func (sd *etcdServiceDiscovery) Init() error {
 		}
 	}()
 
-	go sd.watchEtcdChanges()
 	return nil
 }
 

--- a/cluster/etcd_service_discovery_test.go
+++ b/cluster/etcd_service_discovery_test.go
@@ -158,7 +158,7 @@ func TestEtcdSDBootstrapServer(t *testing.T) {
 			c, cli := helpers.GetTestEtcd(t)
 			defer c.Terminate(t)
 			e := getEtcdSD(t, config, table.server, cli)
-			e.grantLease()
+			e.Init()
 			err := e.bootstrapServer(table.server)
 			assert.NoError(t, err)
 			v, err := cli.Get(context.TODO(), getKey(table.server.ID, table.server.Type))
@@ -183,7 +183,7 @@ func TestEtcdSDDeleteServer(t *testing.T) {
 			c, cli := helpers.GetTestEtcd(t)
 			defer c.Terminate(t)
 			e := getEtcdSD(t, config, table.server, cli)
-			e.grantLease()
+			e.Init()
 			err := e.bootstrapServer(table.server)
 			assert.NoError(t, err)
 			e.deleteServer(table.server.ID)
@@ -243,7 +243,7 @@ func TestEtcdSDGetServer(t *testing.T) {
 			c, cli := helpers.GetTestEtcd(t)
 			defer c.Terminate(t)
 			e := getEtcdSD(t, config, table.server, cli)
-			e.grantLease()
+			e.Init()
 			e.bootstrapServer(table.server)
 			sv, err := e.GetServer(table.server.ID)
 			assert.NoError(t, err)
@@ -259,12 +259,14 @@ func TestEtcdSDGetServers(t *testing.T) {
 		c, cli := helpers.GetTestEtcd(t)
 		defer c.Terminate(t)
 		e := getEtcdSD(t, config, &Server{}, cli)
-		e.grantLease()
+		e.Init()
 		for _, server := range table.servers {
 			e.bootstrapServer(server)
 		}
 		serverList := e.GetServers()
-		assert.ElementsMatch(t, table.servers, serverList)
+		var checkList []*Server
+		checkList = append(table.servers, &Server{})
+		assert.ElementsMatch(t, checkList, serverList)
 	}
 }
 
@@ -335,15 +337,12 @@ func TestEtcdWatchChangesAddNewServers(t *testing.T) {
 	t.Parallel()
 	for _, table := range etcdSDTables {
 		t.Run(table.server.ID, func(t *testing.T) {
-			conf := viper.New()
-			conf.Set("pitaya.cluster.sd.etcd.syncservers.interval", "100ms")
-			config := getConfig(conf)
+			config := getConfig()
 			c, cli := helpers.GetTestEtcd(t)
 			defer c.Terminate(t)
 			e := getEtcdSD(t, config, table.server, cli)
+			e.Init()
 			e.running = true
-			e.bootstrapServer(table.server)
-			e.watchEtcdChanges()
 			serversBefore, err := e.GetServersByType(table.server.Type)
 			assert.NoError(t, err)
 			assert.Equal(t, 1, len(serversBefore))
@@ -369,15 +368,12 @@ func TestEtcdWatchChangesDeleteServers(t *testing.T) {
 	t.Parallel()
 	for _, table := range etcdSDTables {
 		t.Run(table.server.ID, func(t *testing.T) {
-			conf := viper.New()
-			conf.Set("pitaya.cluster.sd.etcd.syncservers.interval", "100ms")
-			config := getConfig(conf)
+			config := getConfig()
 			c, cli := helpers.GetTestEtcd(t)
 			defer c.Terminate(t)
 			e := getEtcdSD(t, config, table.server, cli)
+			e.Init()
 			e.running = true
-			e.bootstrapServer(table.server)
-			e.watchEtcdChanges()
 			serversBefore, err := e.GetServersByType(table.server.Type)
 			assert.NoError(t, err)
 			assert.Equal(t, 1, len(serversBefore))
@@ -416,9 +412,8 @@ func TestEtcdWatchChangesWithBlacklist(t *testing.T) {
 			c, cli := helpers.GetTestEtcd(t)
 			defer c.Terminate(t)
 			e := getEtcdSD(t, config, table.server, cli)
+			e.Init()
 			e.running = true
-			_ = e.bootstrapServer(table.server)
-			e.watchEtcdChanges()
 
 			serversBefore, err := e.GetServersByType(table.server.Type)
 			assert.NoError(t, err)

--- a/config/config.go
+++ b/config/config.go
@@ -79,7 +79,7 @@ func (c *Config) fillDefaultValues() {
 		"pitaya.cluster.sd.etcd.prefix":                         "pitaya/",
 		"pitaya.cluster.sd.etcd.revoke.timeout":                 "5s",
 		"pitaya.cluster.sd.etcd.syncservers.interval":           "120s",
-		"pitaya.cluster.sd.etcd.shutdown.delay":                 "10ms",
+		"pitaya.cluster.sd.etcd.shutdown.delay":                 "300ms",
 		"pitaya.cluster.sd.etcd.servertypeblacklist":            nil,
 		"pitaya.cluster.sd.etcd.syncserversparallelism":         10,
 		// the sum of this config among all the frontend servers should always be less than


### PR DESCRIPTION
This fixes some potential race conditions during syncservers() execution.
- Initialises watcher before initial syncservers() run, to avoid missing put/delete events during syncservers() execution
- Watcher now waits for syncservers() to finish before processing any queued events (for example, after syncservers() gets a list of keys, if the watcher adds a new server it will then get deleted at the end of syncservers()
- Increase the default wait time from 10ms to 300ms for ETCD shutdown, since 10ms is never enough on distributed arquitectures where the servers are in different datacenters more than 10ms apart, leading to some request failures.