### PR TITLE
handle error with InitETCDClient()  #191

### DIFF
--- a/acceptor/tcp_acceptor.go
+++ b/acceptor/tcp_acceptor.go
@@ -138,6 +138,9 @@ func (a *TCPAcceptor) ListenAndServeTLS(cert, key string) {
 	tlsCfg := &tls.Config{Certificates: []tls.Certificate{crt}}
 
 	listener, err := tls.Listen("tcp", a.addr, tlsCfg)
+	if err != nil {
+		logger.Log.Fatalf("Failed to listen: %s", err.Error())
+	}
 	a.listener = listener
 	a.running = true
 	a.serve()

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -266,7 +266,7 @@ func (a *Agent) Close() error {
 	a.SetStatus(constants.StatusClosed)
 
 	logger.Log.Debugf("Session closed, ID=%d, UID=%s, IP=%s",
-		a.Session.ID(), a.Session.UID(), a.conn.RemoteAddr())
+		a.Session.ID(), a.Session.UID(), a.RemoteAddr())
 
 	// prevent closing closed channel
 	select {
@@ -292,7 +292,7 @@ func (a *Agent) RemoteAddr() net.Addr {
 
 // String, implementation for Stringer interface
 func (a *Agent) String() string {
-	return fmt.Sprintf("Remote=%s, LastTime=%d", a.conn.RemoteAddr().String(), atomic.LoadInt64(&a.lastAt))
+	return fmt.Sprintf("Remote=%s, LastTime=%d", a.RemoteAddr().String(), atomic.LoadInt64(&a.lastAt))
 }
 
 // GetStatus gets the status

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -266,7 +266,7 @@ func (a *Agent) Close() error {
 	a.SetStatus(constants.StatusClosed)
 
 	logger.Log.Debugf("Session closed, ID=%d, UID=%s, IP=%s",
-		a.Session.ID(), a.Session.UID(), a.RemoteAddr())
+		a.Session.ID(), a.Session.UID(), a.conn.RemoteAddr())
 
 	// prevent closing closed channel
 	select {
@@ -292,7 +292,7 @@ func (a *Agent) RemoteAddr() net.Addr {
 
 // String, implementation for Stringer interface
 func (a *Agent) String() string {
-	return fmt.Sprintf("Remote=%s, LastTime=%d", a.RemoteAddr().String(), atomic.LoadInt64(&a.lastAt))
+	return fmt.Sprintf("Remote=%s, LastTime=%d", a.conn.RemoteAddr().String(), atomic.LoadInt64(&a.lastAt))
 }
 
 // GetStatus gets the status

--- a/cluster/etcd_service_discovery.go
+++ b/cluster/etcd_service_discovery.go
@@ -375,7 +375,10 @@ func (sd *etcdServiceDiscovery) Init() error {
 	var err error
 
 	if sd.cli == nil {
-		sd.InitETCDClient()
+		err = sd.InitETCDClient()
+		if err != nil {
+			return err
+		}
 	} else {
 		sd.cli.KV = namespace.NewKV(sd.cli.KV, sd.etcdPrefix)
 		sd.cli.Watcher = namespace.NewWatcher(sd.cli.Watcher, sd.etcdPrefix)
@@ -662,7 +665,10 @@ func (sd *etcdServiceDiscovery) watchEtcdChanges() {
 					failedWatchAttempts++
 					time.Sleep(1000 * time.Millisecond)
 					if failedWatchAttempts > 10 {
-						sd.InitETCDClient()
+						if err := sd.InitETCDClient(); err != nil {
+							failedWatchAttempts = 0
+							continue
+						}
 						chn = sd.cli.Watch(context.Background(), "servers/", clientv3.WithPrefix())
 						failedWatchAttempts = 0
 					}


### PR DESCRIPTION
[bug fix] #191 
[bug fix] handle error for tls.Listen, avoid that listener may be nil, which will cause serve() panic