### PR TITLE
some logic optimiztaion

### DIFF
--- a/metrics/prometheus_reporter.go
+++ b/metrics/prometheus_reporter.go
@@ -22,7 +22,7 @@ package metrics
 
 import (
 	"fmt"
-	"log"
+	"github.com/topfreegames/pitaya/logger"
 	"net/http"
 	"sync"
 
@@ -301,7 +301,10 @@ func GetPrometheusReporter(
 		prometheusReporter.registerMetrics(constLabels, additionalLabels, spec)
 		http.Handle("/metrics", promhttp.Handler())
 		go (func() {
-			log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", port), nil))
+			err = http.ListenAndServe(fmt.Sprintf(":%d", port), nil)
+			if err != nil {
+				logger.Log.Error("prometheus reporter serve start failed, err: ", err)
+			}
 		})()
 	})
 

--- a/service/remote.go
+++ b/service/remote.go
@@ -205,9 +205,12 @@ func (r *RemoteService) DoRPC(ctx context.Context, serverID string, route *route
 		Route: route.Short(),
 		Data:  protoData,
 	}
+	if serverID == "" {
+		return r.remoteCall(ctx, nil, protos.RPCType_User, route, nil, msg)
+	}
 
 	target, _ := r.serviceDiscovery.GetServer(serverID)
-	if serverID != "" && target == nil {
+	if target == nil {
 		return nil, constants.ErrServerNotFound
 	}
 

--- a/service/remote.go
+++ b/service/remote.go
@@ -424,7 +424,7 @@ func (r *RemoteService) remoteCall(
 
 	res, err := r.rpcClient.Call(ctx, rpcType, route, session, msg, target)
 	if err != nil {
-		logger.Log.Errorf("error making call to target with id %s and host %s: %w", target.ID, target.Hostname, err)
+		logger.Log.Errorf("error making call to target with id %s route %s and host %s: %w", target.ID, route.String(), target.Hostname, err)
 		return nil, err
 	}
 	return res, err


### PR DESCRIPTION
- prometheus reporter startup with panic
      **when** we start multiple pitaya services on the same host, it will panic because the port of prometheus reporter monitoring fails. Often occurs in the test environment.

- err of remote call should be added with routing information
      **Like**, `msg="error making call to target with id dd953bc8-efbc-4e55-a95a-7ab794a8bcc3 and host xxxx: %!w(*errors.Error=&{PIT-000 xxxxxx map[]})"`  .  I think it is useful to show which handler is called.

- when serverID is empty, execute remoteCall directly. Avoid executing sd.GetServer() once
  logic optimiztaion
