### PR TITLE
Change initial size of get servers return map

### DIFF
--- a/cluster/etcd_service_discovery.go
+++ b/cluster/etcd_service_discovery.go
@@ -304,7 +304,7 @@ func (sd *etcdServiceDiscovery) GetServersByType(serverType string) (map[string]
 		// Create a new map to avoid concurrent read and write access to the
 		// map, this also prevents accidental changes to the list of servers
 		// kept by the service discovery.
-		ret := make(map[string]*Server, len(sd.serverMapByType))
+		ret := make(map[string]*Server, len(sd.serverMapByType[serverType]))
 		for k, v := range sd.serverMapByType[serverType] {
 			ret[k] = v
 		}


### PR DESCRIPTION
Closes #229 

The initial size of the map used to return the servers (on ETCD service discovery) was using an incorrect reference. Even though this mistake didn't cause any issue, changing it makes it less confusing while reading the code.