### PR TITLE
Fix: renable coveralls back online

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -52,12 +52,10 @@ jobs:
       run: make setup-ci
     - name: Run tests
       run: make test-coverage
-    # TODO(luizmiranda7): Coveralls is down for maintenance, 
-    # uncomment this block when it gets back online.
-    # - name: Send coverage
-    #   env:
-    #     COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    #   run: ~/go/bin/goveralls -coverprofile=coverprofile.out -service=github
+    - name: Send coverage
+      env:
+        COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: ~/go/bin/goveralls -coverprofile=coverprofile.out -service=github
   e2e-test-nats:
     name: Nats Test End to End
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description
Coveralls APP is under maintenance, to not block our CI, it's currently disabled.
This PR aims to restore Coveralls step on the test CI pipeline once the APP is back from maintenance.