### PR TITLE
Add post build hooks

### DIFF
--- a/builder_test.go
+++ b/builder_test.go
@@ -1,0 +1,58 @@
+// Copyright (c) nano Author and TFG Co. All Rights Reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package pitaya
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/topfreegames/pitaya/v2/acceptor"
+	"github.com/topfreegames/pitaya/v2/config"
+	"testing"
+)
+
+func TestPostBuildHooks(t *testing.T) {
+	acc := acceptor.NewTCPAcceptor("0.0.0.0:0")
+	for _, table := range tables {
+		builderConfig := config.NewDefaultBuilderConfig()
+
+		t.Run("with_post_build_hooks", func(t *testing.T) {
+			called := false
+			builder := NewDefaultBuilder(table.isFrontend, table.serverType, table.serverMode, table.serverMetadata, *builderConfig)
+			builder.AddAcceptor(acc)
+			builder.AddPostBuildHook(func(app Pitaya) {
+				called = true
+			})
+			app := builder.Build()
+
+			assert.True(t, called)
+			assert.NotNil(t, app)
+		})
+
+		t.Run("without_post_build_hooks", func(t *testing.T) {
+			called := false
+			builder := NewDefaultBuilder(table.isFrontend, table.serverType, table.serverMode, table.serverMetadata, *builderConfig)
+			builder.AddAcceptor(acc)
+			app := builder.Build()
+
+			assert.False(t, called)
+			assert.NotNil(t, app)
+		})
+	}
+}

--- a/docs/builder.md
+++ b/docs/builder.md
@@ -1,0 +1,41 @@
+Builder
+===
+
+Pitaya offers a [`Builder`](../builder.go) object which can be utilized to define a sort of pitaya properties.
+
+### PostBuildHooks
+
+Post-build hooks can be used to execute additional actions automatically after the build process. It also allows you to interact with the built pitaya app.
+
+A common use case is where it becomes necessary to perform configuration steps in both the pitaya builder and the pitaya app being built. In such cases, an effective approach is to internalize these configurations, enabling you to handle them collectively in a single operation or process. It simplifies the overall configuration process, reducing the need for separate and potentially repetitive steps.
+
+```go
+// main.go
+cfg := config.NewDefaultBuilderConfig()
+builder := pitaya.NewDefaultBuilder(isFrontEnd, "my-server-type", pitaya.Cluster, map[string]string{}, *cfg)
+
+customModule := NewCustomModule(builder)
+customModule.ConfigurePitaya(builder)
+
+app := builder.Build()
+
+// custom_object.go
+type CustomObject struct {
+	builder *pitaya.Builder
+}
+
+func NewCustomObject(builder *pitaya.Builder) *CustomObject {
+	return &CustomObject{
+		builder: builder,
+	}
+}
+
+func (object *CustomObject) ConfigurePitaya() {
+	object.builder.AddAcceptor(...)
+	object.builder.AddPostBuildHook(func (app pitaya.App) {
+		app.Register(...)
+	})
+}
+```
+
+In the above example the `ConfigurePitaya` method of the `CustomObject` is adding an `Acceptor` to the pitaya app being built, and also adding a post-build function which will register a handler `Component` that will expose endpoints to receive calls. 


### PR DESCRIPTION
### What does this PR do?

Allow to define callbacks that will be called right after the pitaya app is built.

A possible use case for this can be when you want to customize some pitaya capability and use the generated app in your module and this module should be passed down as reference to another module that also do some configuration on pitaya.

Scenario 1: You have a module that configures pitaya and use the generated app, you can do this by adding a method that should be called after the build.

```go
builder := pitaya.NewDefaultBuilder(...)
myModuleA := NewModuleA(builder)

app := builder.Build()
myModuleA.UseApp(app)
```

Scenario 2: You have two different modules that changes pitaya configuration and use the resultant app, but module B also depends on module A.

```go
// Without post build methods you will end up adding methdos that should be executed after the build
builder := pitaya.NewDefaultBuilder(...)
myModuleA := NewModuleA(builder)
myModuleB := NewModuleB(myModuleA, builder)

app := builder.Build()
myModuleA.UseApp(app)
myModuleB.UseApp(app)
```

Using a post build hook, you don't need to expose those auxiliary methods (which is error-prone since they can be forgotten), making the usage simpler:

```go
// module_a.go
type ModuleA struct {}
func NewModuleA(builder pitaya.Builder) *ModuleA {
    moduleA := &ModuleA{}
    builder.AddPostBuildHook(func (app pitaya.Pitaya) {
        moduleA.UseApp(app)
    })
    
    return moduleA
}

// main.go
builder := pitaya.NewDefaultBuilder(...)
myModuleA := NewModuleA(builder)

builder.Build() // will call the defined post build hooks
```