### PR TITLE
Timeout improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,18 @@ setup-protobuf-macos:
 	@brew install protobuf
 	@go get github.com/golang/protobuf/protoc-gen-go
 
+run-jaeger-aio:
+	@docker-compose -f ./examples/testing/docker-compose-jaeger.yml up -d
+	@echo "Access jaeger UI @ http://localhost:16686"
+
 run-chat-example:
 	@cd examples/testing && docker-compose up -d etcd nats && cd ../demo/chat/ && go run main.go
+
+run-cluster-example-frontend-tracing:
+	@PITAYA_METRICS_PROMETHEUS_PORT=9090 JAEGER_SAMPLER_PARAM=1 JAEGER_DISABLED=false JAEGER_SERVICE_NAME=example-frontend JAEGER_AGENT_PORT=6832 go run examples/demo/cluster/main.go
+
+run-cluster-example-backend-tracing:
+	@PITAYA_METRICS_PROMETHEUS_PORT=9091 JAEGER_SAMPLER_PARAM=1 JAEGER_DISABLED=false JAEGER_SERVICE_NAME=example-backend JAEGER_AGENT_PORT=6832 go run examples/demo/cluster/main.go --port 3251 --type room --frontend=false
 
 run-cluster-example-frontend:
 	@PITAYA_METRICS_PROMETHEUS_PORT=9090 go run examples/demo/cluster/main.go
@@ -73,6 +83,9 @@ ensure-e2e-deps-grpc:
 
 kill-testing-deps:
 	@cd ./examples/testing && docker-compose down; true
+
+kill-jaeger:
+	@docker-compose -f ./examples/testing/docker-compose-jaeger.yml down; true
 
 e2e-test: e2e-test-nats e2e-test-grpc
 

--- a/cluster/nats_rpc_client.go
+++ b/cluster/nats_rpc_client.go
@@ -193,6 +193,14 @@ func (ns *NatsRPCClient) Call(
 	}
 	m, err = ns.conn.Request(getChannel(server.Type, server.ID), marshalledData, ns.reqTimeout)
 	if err != nil {
+		if err == nats.ErrTimeout {
+			err = errors.NewError(constants.ErrRPCRequestTimeout, "PIT-408", map[string]string{
+				"timeout": ns.reqTimeout.String(),
+				"route":   route.String(),
+				"server":  ns.server.ID,
+				"peer.id": server.ID,
+			})
+		}
 		return nil, err
 	}
 

--- a/cluster/nats_rpc_client_test.go
+++ b/cluster/nats_rpc_client_test.go
@@ -377,7 +377,7 @@ func TestNatsRPCClientBuildRequest(t *testing.T) {
 			ctrl := gomock.NewController(t)
 
 			ss := sessionmocks.NewMockSession(ctrl)
-                        if table.rpcType == protos.RPCType_Sys {
+			if table.rpcType == protos.RPCType_Sys {
 				ss.EXPECT().ID().Return(sessionID).Times(1)
 				ss.EXPECT().UID().Return(uid).Times(1)
 				ss.EXPECT().GetDataEncoded().Return(data2).Times(1)
@@ -434,7 +434,7 @@ func TestNatsRPCClientCall(t *testing.T) {
 		{"test_ok", &protos.Response{Data: []byte("ok")}, &protos.Response{Data: []byte("ok")}, nil},
 		{"test_bad_response", []byte("invalid"), nil, errors.New("cannot parse invalid wire-format data")},
 		{"test_bad_proto", &protos.Session{Id: 1, Uid: "snap"}, nil, errors.New("cannot parse invalid wire-format data")},
-		{"test_no_response", nil, nil, errors.New("nats: timeout")},
+		{"test_no_response", nil, nil, constants.ErrRPCRequestTimeout},
 	}
 
 	for _, table := range tables {
@@ -467,7 +467,7 @@ func TestNatsRPCClientCall(t *testing.T) {
 			ss.EXPECT().ID().Return(sessionID).Times(1)
 			ss.EXPECT().UID().Return(uid).Times(1)
 			ss.EXPECT().GetDataEncoded().Return(data2).Times(1)
-			ss.EXPECT().SetRequestInFlight(gomock.Any(),gomock.Any(),gomock.Any()).Times(2)
+			ss.EXPECT().SetRequestInFlight(gomock.Any(), gomock.Any(), gomock.Any()).Times(2)
 
 			res, err := rpcClient.Call(context.Background(), protos.RPCType_Sys, rt, ss, msg, sv2)
 			assert.Equal(t, table.expected, res)

--- a/cluster/nats_rpc_server.go
+++ b/cluster/nats_rpc_server.go
@@ -401,7 +401,7 @@ func (ns *NatsRPCServer) reportMetrics() {
 			}
 
 			// userpushch
-			userPushChanCapacity := ns.messagesBufferSize - len(ns.userPushCh)
+			userPushChanCapacity := ns.pushBufferSize - len(ns.userPushCh)
 			if userPushChanCapacity == 0 {
 				logger.Log.Warn("userPushChan is at maximum capacity")
 			}

--- a/config/config.go
+++ b/config/config.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/topfreegames/pitaya/v2/metrics/models"
@@ -102,11 +101,11 @@ func NewDefaultPitayaConfig() *PitayaConfig {
 		}{
 			Period: time.Duration(15 * time.Second),
 		},
-                Acceptor: struct {
-                        ProxyProtocol bool
-                }{
-                        ProxyProtocol: false,
-                },
+		Acceptor: struct {
+			ProxyProtocol bool
+		}{
+			ProxyProtocol: false,
+		},
 	}
 }
 
@@ -180,7 +179,6 @@ func NewBuilderConfig(config *Config) *BuilderConfig {
 	if err := config.Unmarshal(&conf); err != nil {
 		panic(err)
 	}
-	fmt.Println(conf)
 	return conf
 }
 

--- a/constants/errors.go
+++ b/constants/errors.go
@@ -65,6 +65,7 @@ var (
 	ErrOnCloseBackend                 = errors.New("onclose callbacks are not allowed on backend servers")
 	ErrProtodescriptor                = errors.New("failed to get protobuf message descriptor")
 	ErrPushingToUsers                 = errors.New("failed to push message to users, check array with failed uids")
+	ErrRPCRequestTimeout              = errors.New("rpc client: request timeout")
 	ErrRPCClientNotInitialized        = errors.New("RPC client is not running")
 	ErrRPCJobAlreadyRegistered        = errors.New("rpc job was already registered")
 	ErrRPCLocal                       = errors.New("RPC must be to a different server type")

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,7 @@ Welcome to Pitaya's documentation!
    configuration
    API
    examples
+   tracing
 
 
 Indices and tables

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -1,0 +1,57 @@
+Tracing
+=======
+
+Pitaya supports tracing using [OpenTracing](http://opentracing.io/).
+
+### Using Jaeger tracing
+
+First set the required environment variables:
+
+```bash
+export JAEGER_DISABLED=false
+export JAEGER_SERVICE_NAME=my-pitaya-server
+export JAEGER_SAMPLER_PARAM=1 #Ajust accordingly
+```
+
+With these environment variables set, you can use the following code to configure Jaeger:
+
+```go
+func configureJaeger(config *viper.Viper, logger logrus.FieldLogger) {
+	cfg, err := jaegercfg.FromEnv()
+	if cfg.ServiceName == "" {
+		logger.Error("Could not init jaeger tracer without ServiceName, either set environment JAEGER_SERVICE_NAME or cfg.ServiceName = \"my-api\"")
+		return
+	}
+	if err != nil {
+		logger.Error("Could not parse Jaeger env vars: %s", err.Error())
+		return
+	}
+	options := jaeger.Options{ // import "github.com/topfreegames/pitaya/v2/tracing/jaeger"
+		Disabled:    cfg.Disabled,
+		Probability: cfg.Sampler.Param,
+		ServiceName: cfg.ServiceName,
+	}
+	jaeger.Configure(options)
+}
+```
+
+Then in your main function:
+
+```go
+func main() {
+    // ...
+    configureJaeger(config, logger)
+    // ...
+}
+```
+
+Ensure to run this Jaeger initialization code in all your server types. Only changing the "JAEGER_SERVICE_NAME" env var between different types.
+
+### Testing Locally
+```bash
+make run-jaeger-aio
+make run-cluster-example-frontend-tracing
+make run-cluster-example-backend-tracing
+```
+
+Then access Jaeger UI at http://localhost:16686

--- a/examples/demo/cluster/main.go
+++ b/examples/demo/cluster/main.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"os"
 
 	"strings"
 
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
 	"github.com/topfreegames/pitaya/v2"
 	"github.com/topfreegames/pitaya/v2/acceptor"
 	"github.com/topfreegames/pitaya/v2/cluster"
@@ -15,6 +18,8 @@ import (
 	"github.com/topfreegames/pitaya/v2/examples/demo/cluster/services"
 	"github.com/topfreegames/pitaya/v2/groups"
 	"github.com/topfreegames/pitaya/v2/route"
+	"github.com/topfreegames/pitaya/v2/tracing/jaeger"
+	jaegercfg "github.com/uber/jaeger-client-go/config"
 )
 
 var app pitaya.Pitaya
@@ -73,12 +78,34 @@ func configureFrontend(port int) {
 	}
 }
 
+func configureJaeger(config *viper.Viper, logger logrus.FieldLogger) {
+	cfg, err := jaegercfg.FromEnv()
+	if cfg.ServiceName == "" {
+		logger.Error("Could not init jaeger tracer without ServiceName, either set environment JAEGER_SERVICE_NAME or cfg.ServiceName = \"my-api\"")
+		return
+	}
+	if err != nil {
+		logger.Error("Could not parse Jaeger env vars: %s", err.Error())
+		return
+	}
+	options := jaeger.Options{
+		Disabled:    cfg.Disabled,
+		Probability: cfg.Sampler.Param,
+		ServiceName: cfg.ServiceName,
+	}
+	jaeger.Configure(options)
+}
+
 func main() {
 	port := flag.Int("port", 3250, "the port to listen")
 	svType := flag.String("type", "connector", "the server type")
 	isFrontend := flag.Bool("frontend", true, "if server is frontend")
 
 	flag.Parse()
+
+	if os.Getenv("JAEGER_SERVICE_NAME") != "" {
+		configureJaeger(viper.GetViper(), logrus.New())
+	}
 
 	builder := pitaya.NewDefaultBuilder(*isFrontend, *svType, pitaya.Cluster, map[string]string{}, *config.NewDefaultBuilderConfig())
 	if *isFrontend {
@@ -87,8 +114,6 @@ func main() {
 	}
 	builder.Groups = groups.NewMemoryGroupService(*config.NewDefaultMemoryGroupConfig())
 	app = builder.Build()
-
-	//TODO: Oelze pitaya.SetSerializer(protobuf.NewSerializer())
 
 	defer app.Shutdown()
 

--- a/examples/testing/docker-compose-jaeger.yml
+++ b/examples/testing/docker-compose-jaeger.yml
@@ -1,0 +1,12 @@
+version: '3.7'
+services:
+  jaeger:
+    image: jaegertracing/all-in-one:latest
+    ports:
+      - "16686:16686"
+      - "14268:14268"
+      - "6831:6831/udp"
+      - "6832:6832/udp"
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
+      - LOG_LEVEL=debug

--- a/service/remote.go
+++ b/service/remote.go
@@ -151,21 +151,20 @@ func (r *RemoteService) Call(ctx context.Context, req *protos.Request) (*protos.
 			result <- processRemoteMessage(ctx, req, r)
 		}()
 
-		// Set a timeout for processing the call
-		timeout := time.Duration(4) * time.Second
-
 		reqTimeout := pcontext.GetFromPropagateCtx(ctx, constants.RequestTimeout)
 		if reqTimeout != nil {
+			var timeout time.Duration
 			timeout, err = time.ParseDuration(reqTimeout.(string))
-			if err != nil {
-				logger.Log.Errorf("Error while parsing timeout duration: %s", err.Error())
+			if err == nil {
+				select {
+				case <-time.After(timeout):
+					err = constants.ErrRPCRequestTimeout
+				case res := <-result:
+					return res, nil
+				}
 			}
-		}
-
-		select {
-		case <-time.After(timeout):
-			err = fmt.Errorf("Timed out calling route %s after %s .", req.GetMsg().GetRoute(), timeout)
-		case res := <-result:
+		} else {
+			res := <-result
 			return res, nil
 		}
 	}

--- a/tracing/jaeger/config.go
+++ b/tracing/jaeger/config.go
@@ -25,6 +25,7 @@ package jaeger
 import (
 	"io"
 
+	"github.com/topfreegames/pitaya/v2/logger"
 	"github.com/uber/jaeger-client-go"
 	"github.com/uber/jaeger-client-go/config"
 )
@@ -38,6 +39,7 @@ type Options struct {
 
 // Configure configures a global Jaeger tracer
 func Configure(options Options) (io.Closer, error) {
+	logger.Log.Infof("Configuring Jaeger with options: %+v", options)
 	cfg := config.Configuration{
 		Disabled: options.Disabled,
 		Sampler: &config.SamplerConfig{

--- a/util/util.go
+++ b/util/util.go
@@ -24,11 +24,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/nats-io/nuid"
 	"os"
 	"reflect"
 	"runtime/debug"
 	"strconv"
+
+	"github.com/nats-io/nuid"
 
 	"github.com/topfreegames/pitaya/v2/conn/message"
 	"github.com/topfreegames/pitaya/v2/constants"
@@ -207,7 +208,9 @@ func StartSpanFromRequest(
 	}
 	parent, err := tracing.ExtractSpan(ctx)
 	if err != nil {
-		logger.Log.Warnf("failed to retrieve parent span: %s", err.Error())
+		if err != opentracing.ErrSpanContextNotFound {
+			logger.Log.Warnf("failed to retrieve parent span: %s", err.Error())
+		}
 	}
 	ctx = tracing.StartSpan(ctx, route, tags, parent)
 	return ctx


### PR DESCRIPTION
- Remove redundant context.cancel
- Improve error message for route timeouts, no more clients will see "nats: timeout" but a better error msg with metadata
- Remove default request timeout unless passed by context (we already have a rpc timeout in place that's used by processRemoteMessage)