### PR TITLE
Fix #317, Prevents premature closure of the channel in case of a timeout that leads to a panic

### DIFF
--- a/cluster/etcd_service_discovery.go
+++ b/cluster/etcd_service_discovery.go
@@ -607,9 +607,9 @@ func (sd *etcdServiceDiscovery) Shutdown() error {
 // revoke prevents Pitaya from crashing when etcd is not available
 func (sd *etcdServiceDiscovery) revoke() error {
 	close(sd.stopLeaseChan)
-	c := make(chan error)
-	defer close(c)
+	c := make(chan error, 1)
 	go func() {
+		defer close(c)
 		logger.Log.Debug("waiting for etcd revoke")
 		_, err := sd.cli.Revoke(context.TODO(), sd.leaseID)
 		c <- err


### PR DESCRIPTION
1. Adjusting the timing of channel closures
2. Ensure that the channel is of sufficient size

sorry, the previous pr accidentally added other extraneous information, so I recreated a new pr.