### PR TITLE
The original setup format is not suitable for v2

### DIFF
--- a/examples/demo/custom_metrics/config.yaml
+++ b/examples/demo/custom_metrics/config.yaml
@@ -1,7 +1,10 @@
+metrics:
+  prometheus:
+    enabled: true
 pitaya:
   metrics:
     prometheus:
-      enabled: true
+      port: 9100
     custom:
       counters:
       - subsystem: room


### PR DESCRIPTION
The following three are not under pitaya:
1:Metrics.Prometheus.Enabled
2:Metrics.Statsd.Enabled
3:DefaultPipelines.StructValidation.Enabled

in V2 config/config.go  （type BuilderConfig struct)