### PR TITLE
Fixed an issue where variables were printed with the wrong placeholder

### DIFF
--- a/cluster/etcd_service_discovery.go
+++ b/cluster/etcd_service_discovery.go
@@ -578,7 +578,7 @@ func (sd *etcdServiceDiscovery) SyncServers(firstSync bool) error {
 	servers := parallelGetter.waitAndGetResult()
 
 	for _, server := range servers {
-		logger.Log.Debugf("adding server %s", server)
+		logger.Log.Debugf("adding server %v", server)
 		sd.addServer(server)
 	}
 

--- a/cluster/nats_rpc_server.go
+++ b/cluster/nats_rpc_server.go
@@ -212,7 +212,7 @@ func (ns *NatsRPCServer) handleMessages() {
 			}
 			subsChanLen := float64(len(ns.subChan))
 			maxPending = math.Max(float64(maxPending), subsChanLen)
-			logger.Log.Debugf("subs channel size: %d, max: %d, dropped: %d", subsChanLen, maxPending, dropped)
+			logger.Log.Debugf("subs channel size: %v, max: %v, dropped: %v", subsChanLen, maxPending, dropped)
 			req := &protos.Request{}
 			// TODO: Add tracing here to report delay to start processing message in spans
 			err = proto.Unmarshal(msg.Data, req)

--- a/examples/demo/chat/main.go
+++ b/examples/demo/chat/main.go
@@ -62,7 +62,7 @@ func NewRoom(app pitaya.Pitaya) *Room {
 func (r *Room) AfterInit() {
 	r.timer = pitaya.NewTimer(time.Minute, func() {
 		count, err := r.app.GroupCountMembers(context.Background(), "room")
-		logger.Log.Debugf("UserCount: Time=> %s, Count=> %d, Error=> %q", time.Now().String(), count, err)
+		logger.Log.Debugf("UserCount: Time=> %s, Count=> %d, Error=> %v", time.Now().String(), count, err)
 	})
 }
 


### PR DESCRIPTION
Here are some sample outputs:

before
```
DEBU[0000] adding server &{f8da4226-e555-d75f-bf35-e7e3f9e84945 chat map[] %!s(bool=true) h.dev}  source=pitaya
DEBU[0000] subs channel size: %!d(float64=0), max: %!d(float64=0), dropped: 0  source=tank
```

after
```
DEBU[0000] adding server &{5589a691-ad56-4d31-bca2-55d742d97ece connector map[] true h.dev}  source=pitaya
DEBU[0000] subs channel size: 0, max: 0, dropped: 0      source=pitaya
```