### PR TITLE
Fix stale ETCD routines when ETCD server is unavailable

### DIFF
--- a/cluster/etcd_service_discovery.go
+++ b/cluster/etcd_service_discovery.go
@@ -188,7 +188,7 @@ func (sd *etcdServiceDiscovery) renewLease() error {
 
 func (sd *etcdServiceDiscovery) grantLease() error {
 	// grab lease
-	ctx, cancel := context.WithTimeout(context.Background(), sd.heartbeatTTL)
+	ctx, cancel := context.WithTimeout(context.Background(), sd.etcdDialTimeout)
 	defer cancel()
 	l, err := sd.cli.Grant(ctx, int64(sd.heartbeatTTL.Seconds()))
 	if err != nil {

--- a/cluster/etcd_service_discovery.go
+++ b/cluster/etcd_service_discovery.go
@@ -188,7 +188,7 @@ func (sd *etcdServiceDiscovery) renewLease() error {
 
 func (sd *etcdServiceDiscovery) grantLease() error {
 	// grab lease
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(sd.heartbeatTTL.Seconds()))
+	ctx, cancel := context.WithTimeout(context.Background(), sd.heartbeatTTL)
 	defer cancel()
 	l, err := sd.cli.Grant(ctx, int64(sd.heartbeatTTL.Seconds()))
 	if err != nil {

--- a/cluster/etcd_service_discovery.go
+++ b/cluster/etcd_service_discovery.go
@@ -34,6 +34,7 @@ import (
 	clientv3 "go.etcd.io/etcd/client/v3"
 	logutil "go.etcd.io/etcd/client/pkg/v3/logutil"
 	"go.etcd.io/etcd/client/v3/namespace"
+	"google.golang.org/grpc"
 )
 
 type etcdServiceDiscovery struct {
@@ -187,7 +188,9 @@ func (sd *etcdServiceDiscovery) renewLease() error {
 
 func (sd *etcdServiceDiscovery) grantLease() error {
 	// grab lease
-	l, err := sd.cli.Grant(context.TODO(), int64(sd.heartbeatTTL.Seconds()))
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(sd.heartbeatTTL.Seconds()))
+	defer cancel()
+	l, err := sd.cli.Grant(ctx, int64(sd.heartbeatTTL.Seconds()))
 	if err != nil {
 		return err
 	}
@@ -345,6 +348,7 @@ func (sd *etcdServiceDiscovery) InitETCDClient() error {
 		Endpoints:   sd.etcdEndpoints,
 		DialTimeout: sd.etcdDialTimeout,
 		Logger:      etcdClientLogger,
+		DialOptions: []grpc.DialOption{grpc.WithBlock()},
 	}
 	if sd.etcdUser != "" && sd.etcdPass != "" {
 		config.Username = sd.etcdUser

--- a/cluster/nats_rpc_common.go
+++ b/cluster/nats_rpc_common.go
@@ -52,6 +52,15 @@ func setupNatsConn(connectString string, appDieChan chan bool, options ...nats.O
 				appDieChan <- true
 			}
 		}),
+		nats.ErrorHandler(func(nc *nats.Conn, sub *nats.Subscription, err error) {
+			if err == nats.ErrSlowConsumer {
+				dropped, _ := sub.Dropped()
+				logger.Log.Warn("Slow consumer on subject %q: dropped %d messages\n",
+					sub.Subject, dropped)
+			} else {
+				logger.Log.Errorf(err.Error())
+			}
+		}),
 	)
 
 	nc, err := nats.Connect(connectString, natsOptions...)

--- a/cluster/nats_rpc_common.go
+++ b/cluster/nats_rpc_common.go
@@ -55,7 +55,7 @@ func setupNatsConn(connectString string, appDieChan chan bool, options ...nats.O
 		nats.ErrorHandler(func(nc *nats.Conn, sub *nats.Subscription, err error) {
 			if err == nats.ErrSlowConsumer {
 				dropped, _ := sub.Dropped()
-				logger.Log.Warn("Slow consumer on subject %q: dropped %d messages\n",
+				logger.Log.Warn("nats slow consumer on subject %q: dropped %d messages\n",
 					sub.Subject, dropped)
 			} else {
 				logger.Log.Errorf(err.Error())

--- a/service/handler.go
+++ b/service/handler.go
@@ -23,9 +23,11 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
+	"net"
 
 	"github.com/nats-io/nuid"
 
@@ -181,7 +183,12 @@ func (h *HandlerService) Handle(conn acceptor.PlayerConn) {
 		msg, err := conn.GetNextMessage()
 
 		if err != nil {
-			if err != constants.ErrConnectionClosed {
+			// Check if this is an expected error due to connection being closed
+			if errors.Is(err, net.ErrClosed) {
+				logger.Log.Debugf("Connection no longer available while reading next available message: %s", err.Error())
+			} else if err == constants.ErrConnectionClosed {
+				logger.Log.Debugf("Connection no longer available while reading next available message: %s", err.Error())
+			} else {
 				logger.Log.Errorf("Error reading next available message: %s", err.Error())
 			}
 


### PR DESCRIPTION
- Ensures DialTimeout is respected (this has been broken since it became async on etcd client 3.3.x)
- Sets a deadline on Lease Grant call to ensure it doesn't block forever
- Adds error logs when nats client detects a slow consumer
- Reduces the noise of logs regarding failure to read messages when the remote client has already closed the connection