### PR TITLE
Enrich context with request id and route for remote service calls

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -225,6 +225,15 @@ func GetContextFromRequest(req *protos.Request, serverID string) (context.Contex
 	if ctx == nil {
 		return nil, constants.ErrNoContextFound
 	}
-	ctx = CtxWithDefaultLogger(ctx, req.GetMsg().GetRoute(), "")
+
+	requestID := pcontext.GetFromPropagateCtx(ctx, constants.RequestIDKey)
+	if rID, ok := requestID.(string); !ok || (ok && rID == "") {
+		requestID = nuid.New().Next()
+		ctx = pcontext.AddToPropagateCtx(ctx, constants.RequestIDKey, requestID)
+	}
+
+	route := req.GetMsg().GetRoute()
+	ctx = pcontext.AddToPropagateCtx(ctx, constants.RouteKey, route)
+	ctx = CtxWithDefaultLogger(ctx, route, "")
 	return ctx, nil
 }


### PR DESCRIPTION
The remote calls does not have request id and route in their contexts. This change it to enrich them as it is done in handler calls.