### PR TITLE
Fix pitaya-cli broken refs on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ make setup
 
 Here's one example of running Pitaya:
 
-Start etcd (This command requires docker-compose and will run an etcd container locally. An etcd may be run without docker if prefered.)
+Start etcd (This command requires docker-compose and will run an etcd container locally. An etcd may be run without docker if preferred.)
 ```
 cd ./examples/testing && docker-compose up -d etcd
 ```
@@ -57,7 +57,7 @@ run the room backend server from the cluster_grpc example
 make run-cluster-grpc-example-room
 ```
 
-Now there should be 2 pitaya servers running, a frontend connector and a backend room. To send requests, use a REPL client for pitaya [pitaya-cli](https://github.com/topfreegames/pitaya/tree/main/cli). 
+Now there should be 2 pitaya servers running, a frontend connector and a backend room. To send requests, use a REPL client for pitaya [pitaya-cli](https://github.com/topfreegames/pitaya/tree/main/pitaya-cli).
 
 ```
 $ pitaya-cli
@@ -96,7 +96,7 @@ If you have found a security vulnerability, please email security@tfgco.com
   + [libpitaya](https://github.com/topfreegames/libpitaya)
   + [pitaya-admin](https://github.com/topfreegames/pitaya-admin)
   + [pitaya-bot](https://github.com/topfreegames/pitaya-bot)
-  + [pitaya-cli](https://github.com/topfreegames/pitaya/tree/main/cli)
+  + [pitaya-cli](https://github.com/topfreegames/pitaya/tree/main/pitaya-cli)
   + [pitaya-protos](https://github.com/topfreegames/pitaya-protos)
 
 - Documents

--- a/pitaya-cli/README.md
+++ b/pitaya-cli/README.md
@@ -6,7 +6,7 @@ A REPL cli client made in go for pitaya.
 ## Installing
 
 ```
-go install github.com/topfreegames/pitaya/v2/pitaya-cli
+go install github.com/topfreegames/pitaya-cli/v2@latest
 ```
 
 ## Usage
@@ -80,7 +80,7 @@ func (c *MyHandler) Descriptors(ctx context.Context, names *protos.ProtoNames) (
 }
 ```
 
-When initilizing the CLI, you have to provide the docs route as the following:
+When initializing the CLI, you have to provide the docs route as the following:
 ```
 pitaya-cli -docs connector.docsHandler.docs
 ```


### PR DESCRIPTION
After migrating `pitaya-cli` to the main `pitaya` repo, some references inside the `README.md` broke. Also, the `go install` path from `pitaya-cli/README.md` was broken.