### PR TITLE
feat(cli): add routes command

### DIFF
--- a/pitaya-cli/commands.go
+++ b/pitaya-cli/commands.go
@@ -167,3 +167,27 @@ func disconnect() {
 		pClient.Disconnect()
 	}
 }
+
+func routes(logger Log) error {
+	if pClient == nil {
+		return errors.New("client is not initialized")
+	}
+
+	if !pClient.ConnectedStatus() {
+		return errors.New("not connected")
+	}
+
+	if protoClient, ok := pClient.(*client.ProtoClient); ok {
+		info := protoClient.ExportInformation()
+		if info != nil {
+			for k, _ := range info.Commands {
+				logger.Println(k)
+			}
+		}
+
+	} else {
+		return errors.New("only ProtoClient implements the command `routes`")
+	}
+
+	return nil
+}

--- a/pitaya-cli/file.go
+++ b/pitaya-cli/file.go
@@ -85,7 +85,8 @@ func executeCommand(logger Log, command string) error {
 
 	case "push":
 		return push(logger, parts[1:])
-
+	case "routes":
+		return routes(logger)
 	case "disconnect":
 		disconnect()
 		return nil


### PR DESCRIPTION
Allow pitaya-cli to print routes received by the protoclient. 

example

```
2023/12/12 16:18:12 Using protobuf client
2023/12/12 16:18:12 connected!
2023/12/12 16:18:12 connector.docshandler.descriptors
2023/12/12 16:18:12 connector.docshandler.docs
2023/12/12 16:18:12 connector.sys.bindsession
2023/12/12 16:18:12 connector.sys.kick
2023/12/12 16:18:12 connector.sys.pushsession
```