### PR TITLE
New module type for implementing app level session draining

### DIFF
--- a/app.go
+++ b/app.go
@@ -129,31 +129,32 @@ type Pitaya interface {
 
 // App is the base app struct
 type App struct {
-	acceptors        []acceptor.Acceptor
-	config           config.PitayaConfig
-	debug            bool
-	dieChan          chan bool
-	heartbeat        time.Duration
-	onSessionBind    func(session.Session)
-	router           *router.Router
-	rpcClient        cluster.RPCClient
-	rpcServer        cluster.RPCServer
-	metricsReporters []metrics.Reporter
-	running          bool
-	serializer       serialize.Serializer
-	server           *cluster.Server
-	serverMode       ServerMode
-	serviceDiscovery cluster.ServiceDiscovery
-	startAt          time.Time
-	worker           *worker.Worker
-	remoteService    *service.RemoteService
-	handlerService   *service.HandlerService
-	handlerComp      []regComp
-	remoteComp       []regComp
-	modulesMap       map[string]interfaces.Module
-	modulesArr       []moduleWrapper
-	groups           groups.GroupService
-	sessionPool      session.SessionPool
+	acceptors         []acceptor.Acceptor
+	config            config.PitayaConfig
+	debug             bool
+	dieChan           chan bool
+	heartbeat         time.Duration
+	onSessionBind     func(session.Session)
+	router            *router.Router
+	rpcClient         cluster.RPCClient
+	rpcServer         cluster.RPCServer
+	metricsReporters  []metrics.Reporter
+	running           bool
+	serializer        serialize.Serializer
+	server            *cluster.Server
+	serverMode        ServerMode
+	serviceDiscovery  cluster.ServiceDiscovery
+	startAt           time.Time
+	worker            *worker.Worker
+	remoteService     *service.RemoteService
+	handlerService    *service.HandlerService
+	handlerComp       []regComp
+	remoteComp        []regComp
+	modulesMap        map[string]interfaces.Module
+	modulesArr        []moduleWrapper
+	sessionModulesArr []sessionModuleWrapper
+	groups            groups.GroupService
+	sessionPool       session.SessionPool
 }
 
 // NewApp is the base constructor for a pitaya app instance
@@ -176,29 +177,30 @@ func NewApp(
 	config config.PitayaConfig,
 ) *App {
 	app := &App{
-		server:           server,
-		config:           config,
-		rpcClient:        rpcClient,
-		rpcServer:        rpcServer,
-		worker:           worker,
-		serviceDiscovery: serviceDiscovery,
-		remoteService:    remoteService,
-		handlerService:   handlerService,
-		groups:           groups,
-		debug:            false,
-		startAt:          time.Now(),
-		dieChan:          dieChan,
-		acceptors:        acceptors,
-		metricsReporters: metricsReporters,
-		serverMode:       serverMode,
-		running:          false,
-		serializer:       serializer,
-		router:           router,
-		handlerComp:      make([]regComp, 0),
-		remoteComp:       make([]regComp, 0),
-		modulesMap:       make(map[string]interfaces.Module),
-		modulesArr:       []moduleWrapper{},
-		sessionPool:      sessionPool,
+		server:            server,
+		config:            config,
+		rpcClient:         rpcClient,
+		rpcServer:         rpcServer,
+		worker:            worker,
+		serviceDiscovery:  serviceDiscovery,
+		remoteService:     remoteService,
+		handlerService:    handlerService,
+		groups:            groups,
+		debug:             false,
+		startAt:           time.Now(),
+		dieChan:           dieChan,
+		acceptors:         acceptors,
+		metricsReporters:  metricsReporters,
+		serverMode:        serverMode,
+		running:           false,
+		serializer:        serializer,
+		router:            router,
+		handlerComp:       make([]regComp, 0),
+		remoteComp:        make([]regComp, 0),
+		modulesMap:        make(map[string]interfaces.Module),
+		modulesArr:        []moduleWrapper{},
+		sessionModulesArr: []sessionModuleWrapper{},
+		sessionPool:       sessionPool,
 	}
 	if app.heartbeat == time.Duration(0) {
 		app.heartbeat = config.Heartbeat.Interval
@@ -323,6 +325,15 @@ func (app *App) Start() {
 	sg := make(chan os.Signal)
 	signal.Notify(sg, syscall.SIGINT, syscall.SIGQUIT, syscall.SIGKILL, syscall.SIGTERM)
 
+	maxSessionCount := func() int64 {
+		count := app.sessionPool.GetSessionCount()
+		mc := app.maxModuleSessionCount()
+		if mc > count {
+			count = mc
+		}
+		return count
+	}
+
 	// stop server
 	select {
 	case <-app.dieChan:
@@ -332,9 +343,10 @@ func (app *App) Start() {
 		if app.config.Session.Drain.Enabled && s == syscall.SIGTERM {
 			logger.Log.Info("Session drain is enabled, draining all sessions before shutting down")
 			timeoutTimer := time.NewTimer(app.config.Session.Drain.Timeout)
+			app.startModuleSessionDraining()
 		loop:
 			for {
-				if app.sessionPool.GetSessionCount() == 0 {
+				if maxSessionCount() == 0 {
 					logger.Log.Info("All sessions drained")
 					break loop
 				}
@@ -342,14 +354,14 @@ func (app *App) Start() {
 				case s := <-sg:
 					logger.Log.Warn("got signal: ", s)
 					if s == syscall.SIGINT {
-						logger.Log.Warnf("Bypassing session draing due to SIGINT. %d sessions will be immediately terminated", app.sessionPool.GetSessionCount())
+						logger.Log.Warnf("Bypassing session draing due to SIGINT. %d sessions will be immediately terminated", maxSessionCount())
 					}
 					break loop
 				case <-timeoutTimer.C:
-					logger.Log.Warnf("Session drain has reached maximum timeout. %d sessions will be immediately terminated", app.sessionPool.GetSessionCount())
+					logger.Log.Warnf("Session drain has reached maximum timeout. %d sessions will be immediately terminated", maxSessionCount())
 					break loop
 				case <-time.After(app.config.Session.Drain.Period):
-					logger.Log.Infof("Waiting for all sessions to finish: %d sessions remaining...", app.sessionPool.GetSessionCount())
+					logger.Log.Infof("Waiting for all sessions to finish: %d sessions remaining...", maxSessionCount())
 				}
 			}
 		}

--- a/docs/features.md
+++ b/docs/features.md
@@ -53,17 +53,27 @@ Messages can be pushed to users without previous information about either sessio
 
 Modules are entities that can be registered to the Pitaya application and must implement the defined [interface](https://github.com/topfreegames/pitaya/tree/master/interfaces/interfaces.go#L24). Pitaya is responsible for calling the appropriate lifecycle methods as needed, the registered modules can be retrieved by name.
 
+### SessionModules
+
+SessionModules are an extension of the Module interface. If a module implements the `interfaces.SessionModule` interface, and session draining is enabled in Pitaya, Pitaya will not shut down before all SessionModules report their session count as zero.
+
+When Pitaya receives a SIGTERM signal, it will invoke the `StartSessionDraining` method on all registered SessionModules. After this Pitaya will periodically call the `SessionCount` method on all registered SessionModules to check if they have reached zero.
+
+**Note:** Pitaya will shut down after the session drain timeout has passed, or it receives another signal, even if the session count is not zero.
+
+### Built in modules
+
 Pitaya comes with a few already implemented modules, and more modules can be implemented as needed. The modules Pitaya has currently are:
 
-### Binary
+#### Binary
 
 This module starts a binary as a child process and pipes its stdout and stderr to info and error log messages, respectively.
 
-### Unique session
+#### Unique session
 
 This module adds a callback for `OnSessionBind` that checks if the id being bound has already been bound in one of the other frontend servers.
 
-### Binding storage
+#### Binding storage
 
 This module implements functionality needed by the gRPC RPC implementation to enable the functionality of broadcasting session binds and pushes to users without knowledge of the servers the users are connected to.
 

--- a/interfaces/interfaces.go
+++ b/interfaces/interfaces.go
@@ -28,6 +28,12 @@ type Module interface {
 	Shutdown() error
 }
 
+type SessionModule interface {
+	Module
+	StartSessionDraining()
+	SessionCount() int64
+}
+
 // BindingStorage interface
 type BindingStorage interface {
 	GetUserFrontendID(uid, frontendType string) (string, error)


### PR DESCRIPTION
Introduces a new interface SessionModule. If a Module implements the SessionModule interface it will be treated differently when session draining is enabled.

When session draining starts, Pitaya will call `StartSessionDraining()` on all registered SessionModules. And when checking if sessions have been drained, Pitaya will call `SessionCount()` on all registered SessionModules to check they have all reached zero.