### PR TITLE
Fix/observability gaps

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -511,7 +511,11 @@ func (a *agentImpl) write() {
 					"conn": remoteAddress,
 				}
 
-				ctx = tracing.StartSpan(ctx, "conn write", tags)
+				parent, err := tracing.ExtractSpan(ctx)
+				if err != nil {
+					logger.Log.Warnf("failed to retrieve parent span: %s", err.Error())
+				}
+				ctx = tracing.StartSpan(ctx, "conn write", tags, parent)
 			}
 
 			// close agent if low-level Conn broken

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -498,7 +498,7 @@ func (a *agentImpl) write() {
 	for {
 		select {
 		case pWrite := <-a.chSend:
-			ctx := pWrite.ctx
+			ctx, err, data := pWrite.ctx, pWrite.err, pWrite.data
 
 			if ctx != nil {
 				remoteAddress := ""
@@ -511,28 +511,29 @@ func (a *agentImpl) write() {
 					"conn": remoteAddress,
 				}
 
-				parent, err := tracing.ExtractSpan(ctx)
-				if err != nil {
-					logger.Log.Warnf("failed to retrieve parent span: %s", err.Error())
+				var parent opentracing.SpanContext
+				if span := opentracing.SpanFromContext(ctx); span != nil {
+					parent = span.Context()
 				}
+
 				ctx = tracing.StartSpan(ctx, "conn write", tags, parent)
 			}
 
 			// close agent if low-level Conn broken
-			if _, err := a.conn.Write(pWrite.data); err != nil {
-				err = errors.NewError(err, errors.ErrClientClosedRequest)
+			if _, writeErr := a.conn.Write(data); writeErr != nil {
+				err = errors.NewError(writeErr, errors.ErrClientClosedRequest)
 
 				tracing.FinishSpan(ctx, err)
 				metrics.ReportTimingFromCtx(ctx, a.metricsReporters, handlerType, err)
-
+				
 				logger.Log.Errorf("Failed to write in conn: %s (ctx=%v)", err.Error(), ctx)
 				return
 			}
 
-			tracing.FinishSpan(ctx, pWrite.err)
-			metrics.ReportTimingFromCtx(ctx, a.metricsReporters, handlerType, pWrite.err)
-			if pWrite.err != nil {
-				logger.Log.Errorf("Pending write error: %s", pWrite.err.Error())
+			tracing.FinishSpan(ctx, err)
+			metrics.ReportTimingFromCtx(ctx, a.metricsReporters, handlerType, err)
+			if err != nil {
+				logger.Log.Errorf("Pending write error: %s", err.Error())
 			}
 		case <-a.chStopWrite:
 			return

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -509,15 +509,12 @@ func (a *agentImpl) write() {
 				tracing.FinishSpan(ctx, err)
 				metrics.ReportTimingFromCtx(ctx, a.metricsReporters, handlerType, err)
 
-				logger.Log.Errorf("Failed to write in conn: %s (ctx=%v)", err.Error(), ctx)
+				logger.Log.Errorf("Failed to write in conn: %s (ctx=%v), closing agent", err.Error(), ctx)
 				return
 			}
 
 			tracing.FinishSpan(ctx, err)
 			metrics.ReportTimingFromCtx(ctx, a.metricsReporters, handlerType, err)
-			if err != nil {
-				logger.Log.Errorf("Pending write error: %s", err.Error())
-			}
 		case <-a.chStopWrite:
 			return
 		}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -540,12 +540,12 @@ func (a *agentImpl) AnswerWithError(ctx context.Context, mid uint, err error) {
 	}
 	p, e := util.GetErrorPayload(a.serializer, err)
 	if e != nil {
-		logger.Log.Errorf("error answering route %s with an error: %s", route, e.Error())
+		logger.Log.Errorf("error answering the user with an error: %s", e.Error())
 		return
 	}
 	e = a.Session.ResponseMID(ctx, mid, p, true)
 	if e != nil {
-		logger.Log.Errorf("error answering route %s with an error: %s", route, e.Error())
+		logger.Log.Errorf("error answering the user with an error: %s", e.Error())
 	}
 }
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -502,7 +502,7 @@ func (a *agentImpl) write() {
 		case pWrite := <-a.chSend:
 			ctx, err, data := pWrite.ctx, pWrite.err, pWrite.data
 
-			span := wrapSpan(ctx, a.conn)
+			span := createConnectionSpan(ctx, a.conn, "conn write")
 
 			_, writeErr := a.conn.Write(data)
 
@@ -529,9 +529,9 @@ func (a *agentImpl) write() {
 	}
 }
 
-func wrapSpan(ctx context.Context, conn net.Conn) opentracing.Span {
+func createConnectionSpan(ctx context.Context, conn net.Conn, op string) opentracing.Span {
 	if ctx == nil {
-		return noOpTracer.StartSpan("conn write")
+		return noOpTracer.StartSpan(op)
 	}
 
 	remoteAddress := ""
@@ -549,7 +549,7 @@ func wrapSpan(ctx context.Context, conn net.Conn) opentracing.Span {
 		parent = span.Context()
 	}
 
-	return opentracing.StartSpan("conn write", opentracing.ChildOf(parent), tags)
+	return opentracing.StartSpan(op, opentracing.ChildOf(parent), tags)
 }
 
 // SendRequest sends a request to a server

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -500,14 +500,14 @@ func (a *agentImpl) write() {
 		case pWrite := <-a.chSend:
 			// close agent if low-level Conn broken
 			if _, err := a.conn.Write(pWrite.data); err != nil {
+				err = errors.NewError(err, errors.ErrClientClosedRequest)
+				
 				tracing.FinishSpan(pWrite.ctx, err)
 				metrics.ReportTimingFromCtx(pWrite.ctx, a.metricsReporters, handlerType, err)
 				logger.Log.Errorf("Failed to write in conn: %s (ctx=%v)", err.Error(), pWrite.ctx)
 				return
 			}
-			var e error
-			// TODO check why don't we send pwrite.err to span and we send to report timing
-			tracing.FinishSpan(pWrite.ctx, e)
+			tracing.FinishSpan(pWrite.ctx, pWrite.err)
 			metrics.ReportTimingFromCtx(pWrite.ctx, a.metricsReporters, handlerType, pWrite.err)
 			if pWrite.err != nil {
 				logger.Log.Errorf("Pending write error: %s", pWrite.err.Error())

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -502,7 +502,7 @@ func (a *agentImpl) write() {
 			if _, err := a.conn.Write(pWrite.data); err != nil {
 				tracing.FinishSpan(pWrite.ctx, err)
 				metrics.ReportTimingFromCtx(pWrite.ctx, a.metricsReporters, handlerType, err)
-				logger.Log.Errorf("Failed to write in conn: %s", err.Error())
+				logger.Log.Errorf("Failed to write in conn: %s (ctx=%v)", err.Error(), pWrite.ctx)
 				return
 			}
 			var e error

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -511,7 +511,7 @@ func (a *agentImpl) write() {
 					"conn": remoteAddress,
 				}
 
-				tracing.StartSpan(ctx, "conn write", tags)
+				ctx = tracing.StartSpan(ctx, "conn write", tags)
 			}
 
 			// close agent if low-level Conn broken

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -506,10 +506,11 @@ func (a *agentImpl) write() {
 				return
 			}
 			var e error
+			// TODO check why don't we send pwrite.err to span and we send to report timing
 			tracing.FinishSpan(pWrite.ctx, e)
 			metrics.ReportTimingFromCtx(pWrite.ctx, a.metricsReporters, handlerType, pWrite.err)
 			if pWrite.err != nil {
-				logger.Log.Errorf("Failed to write in conn: %s", pWrite.err.Error())
+				logger.Log.Errorf("Pending write error: %s", pWrite.err.Error())
 			}
 		case <-a.chStopWrite:
 			return

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -498,18 +498,44 @@ func (a *agentImpl) write() {
 	for {
 		select {
 		case pWrite := <-a.chSend:
+			ctx := pWrite.ctx
+
+			var parent opentracing.SpanContext
+			if span := opentracing.SpanFromContext(ctx); span != nil {
+				parent = span.Context()
+			}
+
+			reference := opentracing.ChildOf(parent)
+
+			remoteAddress := ""
+			if a.conn.RemoteAddr() != nil {
+				remoteAddress = a.conn.RemoteAddr().String()
+			}
+
+			tags := opentracing.Tags{
+				"span.kind": "connection",
+				"conn": remoteAddress,
+			}
+
+			span := opentracing.StartSpan("conn write", reference, tags)
+			defer span.Finish()
+
 			// close agent if low-level Conn broken
 			if _, err := a.conn.Write(pWrite.data); err != nil {
 				err = errors.NewError(err, errors.ErrClientClosedRequest)
-				
-				tracing.FinishSpan(pWrite.ctx, err)
-				metrics.ReportTimingFromCtx(pWrite.ctx, a.metricsReporters, handlerType, err)
-				logger.Log.Errorf("Failed to write in conn: %s (ctx=%v)", err.Error(), pWrite.ctx)
+
+				metrics.ReportTimingFromCtx(ctx, a.metricsReporters, handlerType, err)
+
+				tracing.LogError(span, err.Error())
+
+				logger.Log.Errorf("Failed to write in conn: %s (ctx=%v)", err.Error(), ctx)
 				return
 			}
-			tracing.FinishSpan(pWrite.ctx, pWrite.err)
-			metrics.ReportTimingFromCtx(pWrite.ctx, a.metricsReporters, handlerType, pWrite.err)
+
+			metrics.ReportTimingFromCtx(ctx, a.metricsReporters, handlerType, pWrite.err)
 			if pWrite.err != nil {
+				tracing.LogError(span, pWrite.err.Error())
+
 				logger.Log.Errorf("Pending write error: %s", pWrite.err.Error())
 			}
 		case <-a.chStopWrite:

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -508,6 +508,9 @@ func (a *agentImpl) write() {
 			var e error
 			tracing.FinishSpan(pWrite.ctx, e)
 			metrics.ReportTimingFromCtx(pWrite.ctx, a.metricsReporters, handlerType, pWrite.err)
+			if pWrite.err != nil {
+				logger.Log.Errorf("Failed to write in conn: %s", pWrite.err.Error())
+			}
 		case <-a.chStopWrite:
 			return
 		}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -540,12 +540,12 @@ func (a *agentImpl) AnswerWithError(ctx context.Context, mid uint, err error) {
 	}
 	p, e := util.GetErrorPayload(a.serializer, err)
 	if e != nil {
-		logger.Log.Errorf("error answering the user with an error: %s", e.Error())
+		logger.Log.Errorf("error answering route %s with an error: %s", route, e.Error())
 		return
 	}
 	e = a.Session.ResponseMID(ctx, mid, p, true)
 	if e != nil {
-		logger.Log.Errorf("error answering the user with an error: %s", e.Error())
+		logger.Log.Errorf("error answering route %s with an error: %s", route, e.Error())
 	}
 }
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -516,7 +516,7 @@ func (a *agentImpl) write() {
 				logger.Log.Errorf("Failed to write in conn: %s (ctx=%v), closing agent", writeErr.Error(), ctx)
 			}
 
-			tracing.FinishSpan(ctx, err)
+			tracing.FinishSpan(ctx, nil)
 			metrics.ReportTimingFromCtx(ctx, a.metricsReporters, handlerType, err)
 
 			// close agent if low-level conn broke during write

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -258,6 +258,7 @@ func TestAgentSendSerializeErr(t *testing.T) {
 
 	var wg sync.WaitGroup
 	wg.Add(1)
+	mockConn.EXPECT().RemoteAddr().Times(2).Return(&mockAddr{})
 	mockConn.EXPECT().Write(expectedPacket).Do(func(b []byte) {
 		wg.Done()
 	})
@@ -997,6 +998,7 @@ func TestAgentWriteChSend(t *testing.T) {
 
 	var wg sync.WaitGroup
 	wg.Add(1)
+	mockConn.EXPECT().RemoteAddr().Times(2).Return(&mockAddr{})
 	mockConn.EXPECT().Write(expectedPacket).Do(func(b []byte) {
 		time.Sleep(10 * time.Millisecond)
 		wg.Done()

--- a/cluster/nats_rpc_server.go
+++ b/cluster/nats_rpc_server.go
@@ -245,6 +245,8 @@ func (ns *NatsRPCServer) getUserKickChannel() chan *protos.KickMsg {
 func (ns *NatsRPCServer) marshalResponse(res *protos.Response) ([]byte, error) {
 	p, err := proto.Marshal(res)
 	if err != nil {
+		logger.Log.Errorf("error marshaling response: %s", err.Error())
+
 		res := &protos.Response{
 			Error: &protos.Error{
 				Code: e.ErrUnknownCode,
@@ -271,6 +273,8 @@ func (ns *NatsRPCServer) processMessages(threadID int) {
 					Msg:  err.Error(),
 				},
 			}
+			
+			logger.Log.Errorf("error getting context from request: %s", err)
 		} else {
 			ns.responses[threadID], err = ns.pitayaServer.Call(ctx, ns.requests[threadID])
 			if err != nil {

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -36,6 +36,9 @@ const ErrBadRequestCode = "PIT-400"
 // ErrClientClosedRequest is a string code representing the client closed request error
 const ErrClientClosedRequest = "PIT-499"
 
+// ErrClosedRequest is a string code representing the closed request error
+const ErrClosedRequest = "PIT-498"
+
 // Error is an error with a code, message and metadata
 type Error struct {
 	Code     string

--- a/metrics/report.go
+++ b/metrics/report.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/topfreegames/pitaya/v2/constants"
 	"github.com/topfreegames/pitaya/v2/errors"
-	"github.com/topfreegames/pitaya/v2/logger"
 
 	pcontext "github.com/topfreegames/pitaya/v2/context"
 )
@@ -45,9 +44,6 @@ func ReportTimingFromCtx(ctx context.Context, reporters []Reporter, typ string, 
 	if len(reporters) > 0 {
 		startTime := pcontext.GetFromPropagateCtx(ctx, constants.StartTimeKey)
 		route := pcontext.GetFromPropagateCtx(ctx, constants.RouteKey)
-		if code == errors.ErrUnknownCode {
-			logger.Log.Errorf("unknown error reported on route %s: %v", route, err)
-		}
 		elapsed := time.Since(time.Unix(0, startTime.(int64)))
 		tags := getTags(ctx, map[string]string{
 			"route":  route.(string),

--- a/metrics/report.go
+++ b/metrics/report.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/topfreegames/pitaya/v2/constants"
 	"github.com/topfreegames/pitaya/v2/errors"
+	"github.com/topfreegames/pitaya/v2/logger"
 
 	pcontext "github.com/topfreegames/pitaya/v2/context"
 )
@@ -44,6 +45,9 @@ func ReportTimingFromCtx(ctx context.Context, reporters []Reporter, typ string, 
 	if len(reporters) > 0 {
 		startTime := pcontext.GetFromPropagateCtx(ctx, constants.StartTimeKey)
 		route := pcontext.GetFromPropagateCtx(ctx, constants.RouteKey)
+		if code == errors.ErrUnknownCode {
+			logger.Log.Errorf("unknown error reported on route %s: %v", route, err)
+		}
 		elapsed := time.Since(time.Unix(0, startTime.(int64)))
 		tags := getTags(ctx, map[string]string{
 			"route":  route.(string),

--- a/service/handler.go
+++ b/service/handler.go
@@ -352,6 +352,9 @@ func (h *HandlerService) localProcess(ctx context.Context, a agent.Agent, route 
 	} else {
 		metrics.ReportTimingFromCtx(ctx, h.metricsReporters, handlerType, err)
 		tracing.FinishSpan(ctx, err)
+		if err != nil {
+			logger.Log.Errorf("Failed to process notify message: %s", err.Error())
+		}
 	}
 }
 

--- a/service/handler.go
+++ b/service/handler.go
@@ -350,7 +350,7 @@ func (h *HandlerService) localProcess(ctx context.Context, a agent.Agent, route 
 			}
 		}
 	} else {
-		metrics.ReportTimingFromCtx(ctx, h.metricsReporters, handlerType, nil)
+		metrics.ReportTimingFromCtx(ctx, h.metricsReporters, handlerType, err)
 		tracing.FinishSpan(ctx, err)
 	}
 }

--- a/service/handler.go
+++ b/service/handler.go
@@ -344,6 +344,7 @@ func (h *HandlerService) localProcess(ctx context.Context, a agent.Agent, route 
 		} else {
 			err := a.GetSession().ResponseMID(ctx, mid, ret)
 			if err != nil {
+				logger.Log.Errorf("Failed to process handler message: %s", err.Error())
 				tracing.FinishSpan(ctx, err)
 				metrics.ReportTimingFromCtx(ctx, h.metricsReporters, handlerType, err)
 			}

--- a/service/remote.go
+++ b/service/remote.go
@@ -494,6 +494,7 @@ func (r *RemoteService) remoteCall(
 	if target == nil {
 		target, err = r.router.Route(ctx, rpcType, svType, route, msg)
 		if err != nil {
+			logger.Log.Errorf("error making call for route %s: %w", route.String(), err)
 			return nil, e.NewError(err, e.ErrInternalCode)
 		}
 	}


### PR DESCRIPTION
- Add tracing span for connection writes (we're noticing some high times in some of our games, we might want to add a timeout here in the future)
- Properly wrap errors when low-level connection writes fail (they are currently failing with a PIT-000 code in the metrics)
- Add error logging on some spots we were previously missing