### PR TITLE
chore: only output log in debug when we cannot get next message

### DIFF
--- a/pkg/service/handler.go
+++ b/pkg/service/handler.go
@@ -189,7 +189,7 @@ func (h *HandlerService) Handle(conn acceptor.PlayerConn) {
 			} else if err == constants.ErrConnectionClosed {
 				logger.Log.Debugf("Connection no longer available while reading next available message: %s", err.Error())
 			} else {
-				logger.Log.Errorf("Error reading next available message: %s", err.Error())
+				logger.Log.Debugf("Error reading next available message: %s", err.Error())
 			}
 
 			return


### PR DESCRIPTION
The following we observe in production:

```
Error reading next available message: read tcp 192.168.1.1:3250->192.168.1.2:34184: read: connection reset by peer
```

These connections are part of the TCP health-checks which AWS LB does. Healthcheck succeed as it can establish a connection successfully, but pitaya would produce this error log. It might be useful to find such cases but in higher log level - e.g. Debug
