### PR TITLE
feat: customize error codec

### DIFF
--- a/pkg/builder.go
+++ b/pkg/builder.go
@@ -43,6 +43,7 @@ type Builder struct {
 	Worker           *worker.Worker
 	RemoteHooks      *pipeline.RemoteHooks
 	HandlerHooks     *pipeline.HandlerHooks
+	ErrWrapper       serialize.ErrorWrapper
 }
 
 // PitayaBuilder Builder interface
@@ -259,6 +260,10 @@ func (builder *Builder) Build() Pitaya {
 		builder.MetricsReporters,
 		builder.Config,
 	)
+
+	if builder.ErrWrapper != nil {
+		serialize.DefaultErrWrapper = builder.ErrWrapper
+	}
 
 	for _, postBuildHook := range builder.postBuildHooks {
 		postBuildHook(app)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -34,13 +34,10 @@ import (
 	"github.com/topfreegames/pitaya/v3/pkg/conn/message"
 	"github.com/topfreegames/pitaya/v3/pkg/constants"
 	pcontext "github.com/topfreegames/pitaya/v3/pkg/context"
-	e "github.com/topfreegames/pitaya/v3/pkg/errors"
 	"github.com/topfreegames/pitaya/v3/pkg/logger"
 	"github.com/topfreegames/pitaya/v3/pkg/logger/interfaces"
 	"github.com/topfreegames/pitaya/v3/pkg/protos"
 	"github.com/topfreegames/pitaya/v3/pkg/serialize"
-	"github.com/topfreegames/pitaya/v3/pkg/serialize/json"
-	"github.com/topfreegames/pitaya/v3/pkg/serialize/protobuf"
 	"github.com/topfreegames/pitaya/v3/pkg/tracing"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -126,35 +123,12 @@ func FileExists(filename string) bool {
 
 // GetErrorFromPayload gets the error from payload
 func GetErrorFromPayload(serializer serialize.Serializer, payload []byte) error {
-	err := &e.Error{Code: e.ErrUnknownCode}
-	switch serializer.(type) {
-	case *json.Serializer:
-		_ = serializer.Unmarshal(payload, err)
-	case *protobuf.Serializer:
-		pErr := &protos.Error{Code: e.ErrUnknownCode}
-		_ = serializer.Unmarshal(payload, pErr)
-		err = &e.Error{Code: pErr.Code, Message: pErr.Msg, Metadata: pErr.Metadata}
-	}
-	return err
+	return serialize.DefaultErrWrapper.Unmarshal(payload, serializer)
 }
 
 // GetErrorPayload creates and serializes an error payload
 func GetErrorPayload(serializer serialize.Serializer, err error) ([]byte, error) {
-	code := e.ErrUnknownCode
-	msg := err.Error()
-	metadata := map[string]string{}
-	if val, ok := err.(*e.Error); ok {
-		code = val.Code
-		metadata = val.Metadata
-	}
-	errPayload := &protos.Error{
-		Code: code,
-		Msg:  msg,
-	}
-	if len(metadata) > 0 {
-		errPayload.Metadata = metadata
-	}
-	return SerializeOrRaw(serializer, errPayload)
+	return serialize.DefaultErrWrapper.Marshal(err, serializer)
 }
 
 // ConvertProtoToMessageType converts a protos.MsgType to a message.Type


### PR DESCRIPTION
This pull request introduces a new `ErrorWrapper` interface and its default implementation to handle error serialization and deserialization more effectively. The changes impact multiple files, primarily focusing on the `serialize` package and its integration with the `Builder` struct.

### Error Handling Improvements:

* Added `ErrorWrapper` interface and its default implementation `pitayaErrWrapper` to handle custom error serialization and deserialization. (`pkg/serialize/serializer.go`) [[1]](diffhunk://#diff-7060e857cee692f9acd6dbcfe239f76204610b853d87dd1113915a9375cf7973R57-R63) [[2]](diffhunk://#diff-7060e857cee692f9acd6dbcfe239f76204610b853d87dd1113915a9375cf7973R82-R119)
* Updated `GetErrorFromPayload` and `GetErrorPayload` functions to use the new `DefaultErrWrapper` for error handling. (`pkg/util/util.go`)

### Builder Enhancements:

* Added `ErrWrapper` field to the `Builder` struct to allow custom error wrappers. (`pkg/builder.go`)
* Modified the `Build` method to set the `DefaultErrWrapper` if `ErrWrapper` is provided. (`pkg/builder.go`)

### Dependency Updates:

* Updated imports to include necessary packages for the new error handling functionality. (`pkg/serialize/serializer.go`)

also see #371 