### PR TITLE
Fix scenarios where error messages aren't propagated correctly

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -523,6 +523,7 @@ func TestAgentResponseMID(t *testing.T) {
 			expected := pendingWrite{ctx: ctx, data: []byte("ok!"), err: nil}
 			var err error
 			if table.msgErr {
+				mockSerializer.EXPECT().Unmarshal(gomock.Any(), gomock.Any()).Return(nil)
 				err = ag.ResponseMID(ctx, table.mid, table.data, table.msgErr)
 			} else {
 				err = ag.ResponseMID(ctx, table.mid, table.data)
@@ -925,7 +926,13 @@ func TestAgentAnswerWithError(t *testing.T) {
 			name:        "should return unknown code for generic error and JSON serializer",
 			answeredErr: assert.AnError,
 			serializer:  jsonSerializer,
-			expectedErr: e.NewError(errors.New(""), e.ErrUnknownCode),
+			expectedErr: e.NewError(assert.AnError, e.ErrUnknownCode),
+		},
+		{
+			name:        "should return custom code for pitaya error and JSON serializer",
+			answeredErr: e.NewError(assert.AnError, "CUSTOM-123"),
+			serializer:  jsonSerializer,
+			expectedErr: e.NewError(assert.AnError, "CUSTOM-123"),
 		},
 		{
 			name:        "should return unknown code for generic error and Protobuf serializer",
@@ -934,10 +941,22 @@ func TestAgentAnswerWithError(t *testing.T) {
 			expectedErr: e.NewError(assert.AnError, e.ErrUnknownCode),
 		},
 		{
+			name:        "should return custom code for pitaya error and Protobuf serializer",
+			answeredErr: e.NewError(assert.AnError, "CUSTOM-123"),
+			serializer:  protobufSerializer,
+			expectedErr: e.NewError(assert.AnError, "CUSTOM-123"),
+		},
+		{
 			name:        "should return unknown code for generic error and custom serializer",
 			answeredErr: assert.AnError,
 			serializer:  customSerializer,
-			expectedErr: e.NewError(errors.New(""), e.ErrUnknownCode),
+			expectedErr: e.NewError(assert.AnError, e.ErrUnknownCode),
+		},
+		{
+			name:        "should return custom code for pitaya error and custom serializer",
+			answeredErr: e.NewError(assert.AnError, "CUSTOM-123"),
+			serializer:  customSerializer,
+			expectedErr: e.NewError(assert.AnError, "CUSTOM-123"),
 		},
 	}
 

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -22,6 +22,7 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -33,6 +34,8 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/topfreegames/pitaya/v2/conn/codec"
 	codecmocks "github.com/topfreegames/pitaya/v2/conn/codec/mocks"
 	"github.com/topfreegames/pitaya/v2/conn/message"
 	messagemocks "github.com/topfreegames/pitaya/v2/conn/message/mocks"
@@ -45,6 +48,7 @@ import (
 	metricsmocks "github.com/topfreegames/pitaya/v2/metrics/mocks"
 	"github.com/topfreegames/pitaya/v2/mocks"
 	"github.com/topfreegames/pitaya/v2/protos"
+	"github.com/topfreegames/pitaya/v2/serialize"
 	serializemocks "github.com/topfreegames/pitaya/v2/serialize/mocks"
 	"github.com/topfreegames/pitaya/v2/session"
 )
@@ -836,19 +840,39 @@ func TestAgentSendHandshakeResponse(t *testing.T) {
 }
 
 func TestAnswerWithError(t *testing.T) {
-	tables := []struct {
+	unknownError := e.NewError(errors.New(""), e.ErrUnknownCode)
+	table := []struct {
 		name          string
+		answeredErr   error
+		encoderErr    error
 		getPayloadErr error
-		resErr        error
-		err           error
+		expectedErr   error
 	}{
-		{"success", nil, nil, nil},
-		{"failure_get_payload", errors.New("serialize err"), nil, errors.New("serialize err")},
-		{"failure_response_mid", nil, errors.New("responsemid err"), errors.New("responsemid err")},
+		{
+			name:          "should succeed with unknown error",
+			answeredErr:   assert.AnError,
+			encoderErr:    nil,
+			getPayloadErr: nil,
+			expectedErr:   unknownError,
+		},
+		{
+			name:          "should not answer if fails to get payload",
+			answeredErr:   assert.AnError,
+			encoderErr:    nil,
+			getPayloadErr: errors.New("serialize err"),
+			expectedErr:   nil,
+		},
+		{
+			name:          "should not answer if fails to send",
+			answeredErr:   assert.AnError,
+			encoderErr:    assert.AnError,
+			getPayloadErr: nil,
+			expectedErr:   nil,
+		},
 	}
 
-	for _, table := range tables {
-		t.Run(table.name, func(t *testing.T) {
+	for _, row := range table {
+		t.Run(row.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
@@ -861,14 +885,75 @@ func TestAnswerWithError(t *testing.T) {
 			ag := newAgent(nil, nil, mockEncoder, mockSerializer, time.Second, 1, nil, messageEncoder, nil, sessionPool).(*agentImpl)
 			assert.NotNil(t, ag)
 
-			mockSerializer.EXPECT().Marshal(gomock.Any()).Return(nil, table.getPayloadErr)
-			if table.getPayloadErr == nil {
-				mockEncoder.EXPECT().Encode(packet.Type(packet.Data), gomock.Any())
+			mockSerializer.EXPECT().Marshal(gomock.Any()).Return(nil, row.getPayloadErr).AnyTimes()
+			mockSerializer.EXPECT().Unmarshal(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+			mockEncoder.EXPECT().Encode(packet.Type(packet.Data), gomock.Any()).Return(nil, row.encoderErr).AnyTimes()
+
+			ag.AnswerWithError(nil, uint(rand.Int()), row.answeredErr)
+			if row.expectedErr != nil {
+				pWrite := helpers.ShouldEventuallyReceive(t, ag.chSend)
+				assert.Equal(t, pendingWrite{err: row.expectedErr}, pWrite)
 			}
-			ag.AnswerWithError(nil, uint(rand.Int()), errors.New("something went wrong"))
-			if table.err == nil {
-				helpers.ShouldEventuallyReceive(t, ag.chSend)
-			}
+		})
+	}
+}
+
+type customSerializer struct{}
+
+func (*customSerializer) Marshal(obj interface{}) ([]byte, error) { return json.Marshal(obj) }
+func (*customSerializer) Unmarshal(data []byte, obj interface{}) error {
+	return json.Unmarshal(data, obj)
+}
+func (*customSerializer) GetName() string { return "custom" }
+
+func TestAgentAnswerWithError(t *testing.T) {
+	jsonSerializer, err := serialize.NewSerializer(serialize.JSON)
+	require.NoError(t, err)
+
+	protobufSerializer, err := serialize.NewSerializer(serialize.PROTOBUF)
+	require.NoError(t, err)
+
+	customSerializer := &customSerializer{}
+
+	table := []struct {
+		name        string
+		answeredErr error
+		serializer  serialize.Serializer
+		expectedErr error
+	}{
+		{
+			name:        "should return unknown code for generic error and JSON serializer",
+			answeredErr: assert.AnError,
+			serializer:  jsonSerializer,
+			expectedErr: e.NewError(errors.New(""), e.ErrUnknownCode),
+		},
+		{
+			name:        "should return unknown code for generic error and Protobuf serializer",
+			answeredErr: assert.AnError,
+			serializer:  protobufSerializer,
+			expectedErr: e.NewError(assert.AnError, e.ErrUnknownCode),
+		},
+		{
+			name:        "should return unknown code for generic error and custom serializer",
+			answeredErr: assert.AnError,
+			serializer:  customSerializer,
+			expectedErr: e.NewError(errors.New(""), e.ErrUnknownCode),
+		},
+	}
+
+	for _, row := range table {
+		t.Run(row.name, func(t *testing.T) {
+			encoder := codec.NewPomeloPacketEncoder()
+
+			messageEncoder := message.NewMessagesEncoder(false)
+			sessionPool := session.NewSessionPool()
+			ag := newAgent(nil, nil, encoder, row.serializer, time.Second, 1, nil, messageEncoder, nil, sessionPool).(*agentImpl)
+			assert.NotNil(t, ag)
+
+			ag.AnswerWithError(nil, uint(rand.Int()), row.answeredErr)
+
+			pWrite := helpers.ShouldEventuallyReceive(t, ag.chSend)
+			assert.Equal(t, row.expectedErr, pWrite.(pendingWrite).err)
 		})
 	}
 }

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -20,6 +20,8 @@
 
 package errors
 
+import "errors"
+
 // ErrUnknownCode is a string code representing an unknown error
 // This will be used when no error code is sent by the handler
 const ErrUnknownCode = "PIT-000"
@@ -43,9 +45,10 @@ type Error struct {
 	Metadata map[string]string
 }
 
-//NewError ctor
+// NewError ctor
 func NewError(err error, code string, metadata ...map[string]string) *Error {
-	if pitayaErr, ok := err.(*Error); ok {
+	var pitayaErr *Error
+	if ok := errors.As(err, &pitayaErr); ok {
 		if len(metadata) > 0 {
 			mergeMetadatas(pitayaErr, metadata[0])
 		}

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/topfreegames/pitaya/v2/cluster"
 	"github.com/topfreegames/pitaya/v2/cluster/mocks"
 	"github.com/topfreegames/pitaya/v2/conn/message"
+	"github.com/topfreegames/pitaya/v2/constants"
 	"github.com/topfreegames/pitaya/v2/protos"
 	"github.com/topfreegames/pitaya/v2/route"
 )
@@ -107,4 +108,14 @@ func TestAddRoute(t *testing.T) {
 			assert.Nil(t, router.routesMap["anotherServerType"])
 		})
 	}
+}
+
+func TestRouteFailIfNullServiceDiscovery(t *testing.T) {
+	t.Parallel()
+
+	router := New()
+	_, err := router.Route(context.Background(), protos.RPCType_Sys, serverType, route.NewRoute(serverType, "service", "method"), &message.Message{
+		Data: []byte{0x01},
+	})
+	assert.Equal(t, constants.ErrServiceDiscoveryNotInitialized, err)
 }

--- a/service/remote_test.go
+++ b/service/remote_test.go
@@ -345,6 +345,16 @@ func TestRemoteServiceRemoteCall(t *testing.T) {
 			expectedErr: e.NewError(assert.AnError, "CUSTOM-123"),
 		},
 		{
+			name:        "should propagate error for routing wrapped pitaya error",
+			route:       *route.NewRoute("sv", "svc", "method"),
+			serverArg:   nil,
+			routeErr:    fmt.Errorf("wrapper error: %w", e.NewError(assert.AnError, "CUSTOM-123")),
+			callRes:     nil,
+			callErr:     nil,
+			expectedRes: nil,
+			expectedErr: e.NewError(assert.AnError, "CUSTOM-123"),
+		},
+		{
 			name:        "should return error for rpc call error",
 			route:       *route.NewRoute("sv", "svc", "method"),
 			serverArg:   &cluster.Server{Type: "sv"},

--- a/util/util.go
+++ b/util/util.go
@@ -39,8 +39,6 @@ import (
 	"github.com/topfreegames/pitaya/v2/logger/interfaces"
 	"github.com/topfreegames/pitaya/v2/protos"
 	"github.com/topfreegames/pitaya/v2/serialize"
-	"github.com/topfreegames/pitaya/v2/serialize/json"
-	"github.com/topfreegames/pitaya/v2/serialize/protobuf"
 	"github.com/topfreegames/pitaya/v2/tracing"
 
 	opentracing "github.com/opentracing/opentracing-go"
@@ -125,16 +123,9 @@ func FileExists(filename string) bool {
 
 // GetErrorFromPayload gets the error from payload
 func GetErrorFromPayload(serializer serialize.Serializer, payload []byte) error {
-	err := &e.Error{Code: e.ErrUnknownCode}
-	switch serializer.(type) {
-	case *json.Serializer:
-		_ = serializer.Unmarshal(payload, err)
-	case *protobuf.Serializer:
-		pErr := &protos.Error{Code: e.ErrUnknownCode}
-		_ = serializer.Unmarshal(payload, pErr)
-		err = &e.Error{Code: pErr.Code, Message: pErr.Msg, Metadata: pErr.Metadata}
-	}
-	return err
+	pErr := &protos.Error{Code: e.ErrUnknownCode}
+	_ = serializer.Unmarshal(payload, pErr)
+	return &e.Error{Code: pErr.Code, Message: pErr.Msg, Metadata: pErr.Metadata}
 }
 
 // GetErrorPayload creates and serializes an error payload


### PR DESCRIPTION
Currently, there are three scenarios where pitaya errors aren't propagated correctly:

* When pitaya errors are wrapped: `errors.NewError` doesn't make proper use of `errors.As`, triggering the issue.
* When using a custom serializer: in this case, `utils.GetErrorFromPayload` looks for explicit implementations, breaking polymorphism and inducing the bug.
* When using a json serializer: this was caused by `utils.GetErrorPayload`, that would convert any error to the protobuf version of a pitaya error, which would then fail to get parsed by `utils.GetErrorFromPayload`

For my specific case, I encountered these issues when trying to return pitaya errors in the routing function. The first one would convert it to a generic pitaya error `Internal` before returning to clients, and the other two would make error messages not propagate correctly to metrics, having errors as `Unknown` in Prometheus.

This MR fixes all three scenarios, with the following changes:
* `utils.GetErrorFromPayload` now always assumes error payloads are in protobuf schema. This is aligned with the `utils.GetErrorPayload`, which always serializes with the same schema.
* `errors.NewError` now uses `errors.As` when trying to merge pitaya errors.

I also took the time to improve some test cases, implement a few more and test things against pitaya-cli.

Notes:
An alternative would be to make the serialization methods use a non-protobuf schema for JSON. However, the C# `PitayaClient` always assumes errors to be in the protobuf schema, with `code` and `msg` (see [here](https://github.com/topfreegames/libpitaya/blob/master/unity/PitayaExample/Assets/Pitaya/PitayaBinding.cs#L406-L407)). I don't know if that was intentional, or an accidental behavior due to the previously asymmetric `utils.GetErrorFromPayload` and  `utils.GetErrorPayload`.