### PR TITLE
Fix scenarios where error messages aren't propagated correctly (#424)

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -199,6 +199,7 @@ github.com/onsi/ginkgo/v2 v2.1.6/go.mod h1:MEH45j8TBi6u9BMogfbp0stKC5cdGjumZj5Y7
 github.com/orfjackal/nanospec.go v0.0.0-20120727230329-de4694c1d701/go.mod h1:VtBIF1XX0c1nKkeAPk8i4aXkYopqQgfDqolHUIHPwNI=
 github.com/pierrec/lz4/v4 v4.1.18/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
+github.com/prashantv/gostub v1.1.0/go.mod h1:A5zLQHz7ieHGG7is6LLXLz7I8+3LZzsrV0P1IAHhP5U=
 github.com/prometheus/client_model v0.5.0 h1:VQw1hfvPvk3Uv6Qf29VrPF32JB6rtbgI6cYPYQjL0Qw=
 github.com/prometheus/client_model v0.5.0/go.mod h1:dTiFglRmd66nLR9Pv9f0mZi7B7fk5Pm3gvsjB5tr+kI=
 github.com/r3labs/sse/v2 v2.10.0/go.mod h1:Igau6Whc+F17QUgML1fYe1VPZzTV6EMCnYktEmkNJ7I=

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -20,6 +20,8 @@
 
 package errors
 
+import "errors"
+
 // ErrUnknownCode is a string code representing an unknown error
 // This will be used when no error code is sent by the handler
 const ErrUnknownCode = "PIT-000"
@@ -46,9 +48,10 @@ type Error struct {
 	Metadata map[string]string
 }
 
-//NewError ctor
+// NewError ctor
 func NewError(err error, code string, metadata ...map[string]string) *Error {
-	if pitayaErr, ok := err.(*Error); ok {
+	var pitayaErr *Error
+	if ok := errors.As(err, &pitayaErr); ok {
 		if len(metadata) > 0 {
 			mergeMetadatas(pitayaErr, metadata[0])
 		}

--- a/pkg/groups/etcd_group_service.go
+++ b/pkg/groups/etcd_group_service.go
@@ -6,12 +6,12 @@ import (
 	"sync"
 	"time"
 
-	clientv3 "go.etcd.io/etcd/client/v3"
-	"go.etcd.io/etcd/client/v3/namespace"
-	"go.etcd.io/etcd/api/v3/mvccpb"
 	"github.com/topfreegames/pitaya/v3/pkg/config"
 	"github.com/topfreegames/pitaya/v3/pkg/constants"
 	"github.com/topfreegames/pitaya/v3/pkg/logger"
+	"go.etcd.io/etcd/api/v3/mvccpb"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/client/v3/namespace"
 )
 
 var (
@@ -22,6 +22,7 @@ var (
 
 // EtcdGroupService base ETCD struct solution
 type EtcdGroupService struct {
+	cancelFunc context.CancelFunc
 }
 
 // NewEtcdGroupService returns a new group instance
@@ -281,4 +282,10 @@ func (c *EtcdGroupService) GroupRenewTTL(ctx context.Context, groupName string) 
 		return err
 	}
 	return constants.ErrEtcdLeaseNotFound
+}
+
+func (c *EtcdGroupService) Close() {
+	if c.cancelFunc != nil {
+		c.cancelFunc()
+	}
 }

--- a/pkg/groups/etcd_group_service_test.go
+++ b/pkg/groups/etcd_group_service_test.go
@@ -41,65 +41,76 @@ func setup(t *testing.T) (*integration.ClusterV3, GroupService) {
 func TestEtcdCreateDuplicatedGroup(t *testing.T) {
 	cluster, etcdGroupService := setup(t)
 	defer cluster.Terminate(t)
+	defer etcdGroupService.Close()
 	testCreateDuplicatedGroup(etcdGroupService, t)
 }
 
 func TestEtcdCreateGroup(t *testing.T) {
 	cluster, etcdGroupService := setup(t)
 	defer cluster.Terminate(t)
+	defer etcdGroupService.Close()
 	testCreateGroup(etcdGroupService, t)
 }
 
 func TestEtcdCreateGroupWithTTL(t *testing.T) {
 	cluster, etcdGroupService := setup(t)
 	defer cluster.Terminate(t)
+	defer etcdGroupService.Close()
 	testCreateGroupWithTTL(etcdGroupService, t)
 }
 
 func TestEtcdGroupAddMember(t *testing.T) {
 	cluster, etcdGroupService := setup(t)
 	defer cluster.Terminate(t)
+	defer etcdGroupService.Close()
 	testGroupAddMember(etcdGroupService, t)
 }
 
 func TestEtcdGroupAddDuplicatedMember(t *testing.T) {
 	cluster, etcdGroupService := setup(t)
 	defer cluster.Terminate(t)
+	defer etcdGroupService.Close()
 	testGroupAddDuplicatedMember(etcdGroupService, t)
 }
 
 func TestEtcdGroupContainsMember(t *testing.T) {
 	cluster, etcdGroupService := setup(t)
 	defer cluster.Terminate(t)
+	defer etcdGroupService.Close()
 	testGroupContainsMember(etcdGroupService, t)
 }
 
 func TestEtcdRemove(t *testing.T) {
 	cluster, etcdGroupService := setup(t)
 	defer cluster.Terminate(t)
+	defer etcdGroupService.Close()
 	testRemove(etcdGroupService, t)
 }
 
 func TestEtcdDelete(t *testing.T) {
 	cluster, etcdGroupService := setup(t)
 	defer cluster.Terminate(t)
+	defer etcdGroupService.Close()
 	testDelete(etcdGroupService, t)
 }
 
 func TestEtcdRemoveAll(t *testing.T) {
 	cluster, etcdGroupService := setup(t)
 	defer cluster.Terminate(t)
+	defer etcdGroupService.Close()
 	testRemoveAll(etcdGroupService, t)
 }
 
 func TestEtcdCount(t *testing.T) {
 	cluster, etcdGroupService := setup(t)
 	defer cluster.Terminate(t)
+	defer etcdGroupService.Close()
 	testCount(etcdGroupService, t)
 }
 
 func TestEtcdMembers(t *testing.T) {
 	cluster, etcdGroupService := setup(t)
 	defer cluster.Terminate(t)
+	defer etcdGroupService.Close()
 	testMembers(etcdGroupService, t)
 }

--- a/pkg/groups/group_service.go
+++ b/pkg/groups/group_service.go
@@ -18,6 +18,7 @@ type (
 		GroupRemoveAll(ctx context.Context, groupName string) error
 		GroupRemoveMember(ctx context.Context, groupName, uid string) error
 		GroupRenewTTL(ctx context.Context, groupName string) error
+		Close()
 	}
 )
 

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/topfreegames/pitaya/v3/pkg/cluster"
 	"github.com/topfreegames/pitaya/v3/pkg/cluster/mocks"
 	"github.com/topfreegames/pitaya/v3/pkg/conn/message"
+	"github.com/topfreegames/pitaya/v3/pkg/constants"
 	"github.com/topfreegames/pitaya/v3/pkg/protos"
 	"github.com/topfreegames/pitaya/v3/pkg/route"
 )
@@ -107,4 +108,14 @@ func TestAddRoute(t *testing.T) {
 			assert.Nil(t, router.routesMap["anotherServerType"])
 		})
 	}
+}
+
+func TestRouteFailIfNullServiceDiscovery(t *testing.T) {
+	t.Parallel()
+
+	router := New()
+	_, err := router.Route(context.Background(), protos.RPCType_Sys, serverType, route.NewRoute(serverType, "service", "method"), &message.Message{
+		Data: []byte{0x01},
+	})
+	assert.Equal(t, constants.ErrServiceDiscoveryNotInitialized, err)
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -39,8 +39,6 @@ import (
 	"github.com/topfreegames/pitaya/v3/pkg/logger/interfaces"
 	"github.com/topfreegames/pitaya/v3/pkg/protos"
 	"github.com/topfreegames/pitaya/v3/pkg/serialize"
-	"github.com/topfreegames/pitaya/v3/pkg/serialize/json"
-	"github.com/topfreegames/pitaya/v3/pkg/serialize/protobuf"
 	"github.com/topfreegames/pitaya/v3/pkg/tracing"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -126,16 +124,9 @@ func FileExists(filename string) bool {
 
 // GetErrorFromPayload gets the error from payload
 func GetErrorFromPayload(serializer serialize.Serializer, payload []byte) error {
-	err := &e.Error{Code: e.ErrUnknownCode}
-	switch serializer.(type) {
-	case *json.Serializer:
-		_ = serializer.Unmarshal(payload, err)
-	case *protobuf.Serializer:
-		pErr := &protos.Error{Code: e.ErrUnknownCode}
-		_ = serializer.Unmarshal(payload, pErr)
-		err = &e.Error{Code: pErr.Code, Message: pErr.Msg, Metadata: pErr.Metadata}
-	}
-	return err
+	pErr := &protos.Error{Code: e.ErrUnknownCode}
+	_ = serializer.Unmarshal(payload, pErr)
+	return &e.Error{Code: pErr.Code, Message: pErr.Msg, Metadata: pErr.Metadata}
 }
 
 // GetErrorPayload creates and serializes an error payload


### PR DESCRIPTION
Porting the routing fix that @felippeduran provided to main/v3. See #424 

* Improve tests for agent and service/remote to expose bad behaviors
* Breakdown test into multiple ones to make them more clear
* Fix scenarios where error messages aren't propagated correctly

---------