### PR TITLE
feat(agent): add timeout on write calls

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -263,8 +263,9 @@ func (a *agentImpl) packetEncodeMessage(m *message.Message) ([]byte, error) {
 
 func (a *agentImpl) send(pendingMsg pendingMessage) (err error) {
 	defer func() {
-		if e := recover(); e != nil {
-			err = errors.NewError(constants.ErrBrokenPipe, errors.ErrClientClosedRequest)
+		if panicErr := recover(); panicErr != nil {
+			brokenPipeErr := errors.NewError(constants.ErrBrokenPipe, errors.ErrClientClosedRequest)
+			err = fmt.Errorf("%w: %v", brokenPipeErr, panicErr)
 		}
 	}()
 	a.reportChannelSize()

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -26,6 +26,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"os"
 	"reflect"
 	"sync"
 	"testing"
@@ -81,6 +82,7 @@ func TestNewAgent(t *testing.T) {
 	mockDecoder := codecmocks.NewMockPacketDecoder(ctrl)
 	dieChan := make(chan bool)
 	hbTime := time.Second
+	writeTimeout := time.Second
 
 	mockConn := mocks.NewMockPlayerConn(ctrl)
 
@@ -99,7 +101,7 @@ func TestNewAgent(t *testing.T) {
 	sessionPool := session.NewSessionPool()
 
 	mockMetricsReporter.EXPECT().ReportGauge(metrics.ConnectedClients, gomock.Any(), gomock.Any())
-	ag := newAgent(mockConn, mockDecoder, mockEncoder, mockSerializer, hbTime, 10, dieChan, messageEncoder, mockMetricsReporters, sessionPool).(*agentImpl)
+	ag := newAgent(mockConn, mockDecoder, mockEncoder, mockSerializer, hbTime, writeTimeout, 10, dieChan, messageEncoder, mockMetricsReporters, sessionPool).(*agentImpl)
 	assert.NotNil(t, ag)
 	assert.IsType(t, make(chan struct{}), ag.chDie)
 	assert.IsType(t, make(chan pendingWrite), ag.chSend)
@@ -110,7 +112,7 @@ func TestNewAgent(t *testing.T) {
 	assert.Equal(t, mockConn, ag.conn)
 	assert.Equal(t, mockDecoder, ag.decoder)
 	assert.Equal(t, mockEncoder, ag.encoder)
-	assert.Equal(t, hbTime, ag.heartbeatTimeout)
+	assert.Equal(t, hbTime, writeTimeout, ag.heartbeatTimeout)
 	assert.InDelta(t, time.Now().Unix(), ag.lastAt, 1)
 	assert.Equal(t, mockSerializer, ag.serializer)
 	assert.Equal(t, mockMetricsReporters, ag.metricsReporters)
@@ -120,7 +122,7 @@ func TestNewAgent(t *testing.T) {
 
 	// second call should no call hdb encode
 	mockMetricsReporter.EXPECT().ReportGauge(metrics.ConnectedClients, gomock.Any(), gomock.Any())
-	ag = newAgent(nil, nil, mockEncoder, mockSerializer, hbTime, 10, dieChan, messageEncoder, mockMetricsReporters, sessionPool).(*agentImpl)
+	ag = newAgent(nil, nil, mockEncoder, mockSerializer, hbTime, writeTimeout, 10, dieChan, messageEncoder, mockMetricsReporters, sessionPool).(*agentImpl)
 	assert.NotNil(t, ag)
 }
 
@@ -133,6 +135,7 @@ func TestKick(t *testing.T) {
 	mockDecoder := codecmocks.NewMockPacketDecoder(ctrl)
 	dieChan := make(chan bool)
 	hbTime := time.Second
+	writeTimeout := time.Second
 
 	mockConn := mocks.NewMockPlayerConn(ctrl)
 	mockEncoder.EXPECT().Encode(gomock.Any(), gomock.Nil()).Do(
@@ -145,7 +148,7 @@ func TestKick(t *testing.T) {
 	mockSerializer.EXPECT().GetName()
 
 	sessionPool := session.NewSessionPool()
-	ag := newAgent(mockConn, mockDecoder, mockEncoder, mockSerializer, hbTime, 10, dieChan, messageEncoder, nil, sessionPool)
+	ag := newAgent(mockConn, mockDecoder, mockEncoder, mockSerializer, hbTime, writeTimeout, 10, dieChan, messageEncoder, nil, sessionPool)
 	c := context.Background()
 	err := ag.Kick(c)
 	assert.NoError(t, err)
@@ -171,12 +174,13 @@ func TestAgentSend(t *testing.T) {
 			mockDecoder := codecmocks.NewMockPacketDecoder(ctrl)
 			dieChan := make(chan bool)
 			hbTime := time.Second
+			writeTimeout := time.Second
 			messageEncoder := message.NewMessagesEncoder(false)
 
 			mockConn := mocks.NewMockPlayerConn(ctrl)
 			mockSerializer.EXPECT().GetName()
 			sessionPool := session.NewSessionPool()
-			ag := newAgent(mockConn, mockDecoder, mockEncoder, mockSerializer, hbTime, 10, dieChan, messageEncoder, nil, sessionPool).(*agentImpl)
+			ag := newAgent(mockConn, mockDecoder, mockEncoder, mockSerializer, hbTime, writeTimeout, 10, dieChan, messageEncoder, nil, sessionPool).(*agentImpl)
 			assert.NotNil(t, ag)
 
 			if table.err != nil {
@@ -263,6 +267,7 @@ func TestAgentSendSerializeErr(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 	mockConn.EXPECT().RemoteAddr().Times(2).Return(&mockAddr{})
+	mockConn.EXPECT().SetWriteDeadline(gomock.Any()).Return(nil)
 	mockConn.EXPECT().Write(expectedPacket).Do(func(b []byte) {
 		wg.Done()
 	})
@@ -285,7 +290,7 @@ func TestAgentPushFailsIfClosedAgent(t *testing.T) {
 	messageEncoder := message.NewMessagesEncoder(false)
 
 	sessionPool := session.NewSessionPool()
-	ag := newAgent(nil, nil, mockEncoder, mockSerializer, time.Second, 10, nil, messageEncoder, nil, sessionPool).(*agentImpl)
+	ag := newAgent(nil, nil, mockEncoder, mockSerializer, time.Second, time.Second, 10, nil, messageEncoder, nil, sessionPool).(*agentImpl)
 	assert.NotNil(t, ag)
 	ag.state = constants.StatusClosed
 	err := ag.Push("", nil)
@@ -312,6 +317,7 @@ func TestAgentPushStruct(t *testing.T) {
 			mockDecoder := codecmocks.NewMockPacketDecoder(ctrl)
 			dieChan := make(chan bool)
 			hbTime := time.Second
+			writeTimeout := time.Second
 			messageEncoder := message.NewMessagesEncoder(false)
 			mockMetricsReporter := metricsmocks.NewMockReporter(ctrl)
 			mockConn := mocks.NewMockPlayerConn(ctrl)
@@ -319,7 +325,7 @@ func TestAgentPushStruct(t *testing.T) {
 			mockMetricsReporter.EXPECT().ReportGauge(metrics.ConnectedClients, gomock.Any(), gomock.Any())
 			mockSerializer.EXPECT().GetName()
 			sessionPool := session.NewSessionPool()
-			ag := newAgent(mockConn, mockDecoder, mockEncoder, mockSerializer, hbTime, 10, dieChan, messageEncoder, mockMetricsReporters, sessionPool).(*agentImpl)
+			ag := newAgent(mockConn, mockDecoder, mockEncoder, mockSerializer, hbTime, writeTimeout, 10, dieChan, messageEncoder, mockMetricsReporters, sessionPool).(*agentImpl)
 			assert.NotNil(t, ag)
 
 			expectedBytes := []byte("hello")
@@ -371,6 +377,7 @@ func TestAgentPush(t *testing.T) {
 			mockDecoder := codecmocks.NewMockPacketDecoder(ctrl)
 			dieChan := make(chan bool)
 			hbTime := time.Second
+			writeTimeout := time.Second
 			messageEncoder := message.NewMessagesEncoder(false)
 			mockMetricsReporter := metricsmocks.NewMockReporter(ctrl)
 			mockConn := mocks.NewMockPlayerConn(ctrl)
@@ -378,7 +385,7 @@ func TestAgentPush(t *testing.T) {
 			mockMetricsReporter.EXPECT().ReportGauge(metrics.ConnectedClients, gomock.Any(), gomock.Any())
 			mockSerializer.EXPECT().GetName()
 			sessionPool := session.NewSessionPool()
-			ag := newAgent(mockConn, mockDecoder, mockEncoder, mockSerializer, hbTime, 10, dieChan, messageEncoder, mockMetricsReporters, sessionPool).(*agentImpl)
+			ag := newAgent(mockConn, mockDecoder, mockEncoder, mockSerializer, hbTime, writeTimeout, 10, dieChan, messageEncoder, mockMetricsReporters, sessionPool).(*agentImpl)
 			assert.NotNil(t, ag)
 
 			expectedBytes := []byte("hello")
@@ -418,6 +425,7 @@ func TestAgentPushFullChannel(t *testing.T) {
 	mockDecoder := codecmocks.NewMockPacketDecoder(ctrl)
 	dieChan := make(chan bool)
 	hbTime := time.Second
+	writeTimeout := time.Second
 	messageEncoder := message.NewMessagesEncoder(false)
 	mockMetricsReporter := metricsmocks.NewMockReporter(ctrl)
 	mockConn := mocks.NewMockPlayerConn(ctrl)
@@ -425,7 +433,7 @@ func TestAgentPushFullChannel(t *testing.T) {
 	mockMetricsReporter.EXPECT().ReportGauge(metrics.ConnectedClients, gomock.Any(), gomock.Any())
 	mockSerializer.EXPECT().GetName()
 	sessionPool := session.NewSessionPool()
-	ag := newAgent(mockConn, mockDecoder, mockEncoder, mockSerializer, hbTime, 0, dieChan, messageEncoder, mockMetricsReporters, sessionPool).(*agentImpl)
+	ag := newAgent(mockConn, mockDecoder, mockEncoder, mockSerializer, hbTime, writeTimeout, 0, dieChan, messageEncoder, mockMetricsReporters, sessionPool).(*agentImpl)
 	assert.NotNil(t, ag)
 
 	mockMetricsReporter.EXPECT().ReportGauge(metrics.ChannelCapacity, gomock.Any(), float64(0))
@@ -461,7 +469,7 @@ func TestAgentResponseMIDFailsIfClosedAgent(t *testing.T) {
 	mockMetricsReporters := []metrics.Reporter{mockMetricsReporter}
 	mockMetricsReporter.EXPECT().ReportGauge(metrics.ConnectedClients, gomock.Any(), gomock.Any())
 	sessionPool := session.NewSessionPool()
-	ag := newAgent(nil, nil, mockEncoder, mockSerializer, time.Second, 10, nil, mockMessageEncoder, mockMetricsReporters, sessionPool).(*agentImpl)
+	ag := newAgent(nil, nil, mockEncoder, mockSerializer, time.Second, time.Second, 10, nil, mockMessageEncoder, mockMetricsReporters, sessionPool).(*agentImpl)
 	assert.NotNil(t, ag)
 	ag.state = constants.StatusClosed
 
@@ -498,6 +506,7 @@ func TestAgentResponseMID(t *testing.T) {
 			mockDecoder := codecmocks.NewMockPacketDecoder(ctrl)
 			dieChan := make(chan bool)
 			hbTime := time.Second
+			writeTimeout := time.Second
 			messageEncoder := message.NewMessagesEncoder(false)
 
 			mockConn := mocks.NewMockPlayerConn(ctrl)
@@ -505,7 +514,7 @@ func TestAgentResponseMID(t *testing.T) {
 			mockMetricsReporter.EXPECT().ReportGauge(metrics.ConnectedClients, gomock.Any(), gomock.Any())
 			mockSerializer.EXPECT().GetName()
 			sessionPool := session.NewSessionPool()
-			ag := newAgent(mockConn, mockDecoder, mockEncoder, mockSerializer, hbTime, 10, dieChan, messageEncoder, mockMetricsReporters, sessionPool).(*agentImpl)
+			ag := newAgent(mockConn, mockDecoder, mockEncoder, mockSerializer, hbTime, writeTimeout, 10, dieChan, messageEncoder, mockMetricsReporters, sessionPool).(*agentImpl)
 			assert.NotNil(t, ag)
 
 			ctx := getCtxWithRequestKeys()
@@ -553,6 +562,7 @@ func TestAgentResponseMIDFullChannel(t *testing.T) {
 	mockDecoder := codecmocks.NewMockPacketDecoder(ctrl)
 	dieChan := make(chan bool)
 	hbTime := time.Second
+	writeTimeout := time.Second
 	messageEncoder := message.NewMessagesEncoder(false)
 	mockMetricsReporter := metricsmocks.NewMockReporter(ctrl)
 	mockConn := mocks.NewMockPlayerConn(ctrl)
@@ -561,7 +571,7 @@ func TestAgentResponseMIDFullChannel(t *testing.T) {
 	mockSerializer.EXPECT().GetName()
 	mockEncoder.EXPECT().Encode(packet.Type(packet.Data), gomock.Any())
 	sessionPool := session.NewSessionPool()
-	ag := newAgent(mockConn, mockDecoder, mockEncoder, mockSerializer, hbTime, 0, dieChan, messageEncoder, mockMetricsReporters, sessionPool).(*agentImpl)
+	ag := newAgent(mockConn, mockDecoder, mockEncoder, mockSerializer, hbTime, writeTimeout, 0, dieChan, messageEncoder, mockMetricsReporters, sessionPool).(*agentImpl)
 	assert.NotNil(t, ag)
 	mockMetricsReporters[0].(*metricsmocks.MockReporter).EXPECT().ReportGauge(metrics.ChannelCapacity, gomock.Any(), float64(0))
 	go func() {
@@ -582,7 +592,7 @@ func TestAgentCloseFailsIfAlreadyClosed(t *testing.T) {
 	mockSerializer.EXPECT().GetName()
 
 	sessionPool := session.NewSessionPool()
-	ag := newAgent(nil, nil, mockEncoder, mockSerializer, time.Second, 10, nil, mockMessageEncoder, nil, sessionPool).(*agentImpl)
+	ag := newAgent(nil, nil, mockEncoder, mockSerializer, time.Second, time.Second, 10, nil, mockMessageEncoder, nil, sessionPool).(*agentImpl)
 	assert.NotNil(t, ag)
 	ag.state = constants.StatusClosed
 	err := ag.Close()
@@ -601,7 +611,7 @@ func TestAgentClose(t *testing.T) {
 	mockSerializer.EXPECT().GetName()
 
 	sessionPool := session.NewSessionPool()
-	ag := newAgent(mockConn, nil, mockEncoder, mockSerializer, time.Second, 0, nil, mockMessageEncoder, nil, sessionPool).(*agentImpl)
+	ag := newAgent(mockConn, nil, mockEncoder, mockSerializer, time.Second, time.Second, 0, nil, mockMessageEncoder, nil, sessionPool).(*agentImpl)
 	assert.NotNil(t, ag)
 
 	expected := false
@@ -649,7 +659,7 @@ func TestAgentRemoteAddr(t *testing.T) {
 	mockSerializer.EXPECT().GetName()
 
 	sessionPool := session.NewSessionPool()
-	ag := newAgent(mockConn, nil, mockEncoder, mockSerializer, time.Second, 0, nil, mockMessageEncoder, nil, sessionPool)
+	ag := newAgent(mockConn, nil, mockEncoder, mockSerializer, time.Second, time.Second, 0, nil, mockMessageEncoder, nil, sessionPool)
 	assert.NotNil(t, ag)
 
 	expected := &mockAddr{}
@@ -670,7 +680,7 @@ func TestAgentString(t *testing.T) {
 	mockSerializer.EXPECT().GetName()
 
 	sessionPool := session.NewSessionPool()
-	ag := newAgent(mockConn, nil, mockEncoder, mockSerializer, time.Second, 0, nil, mockMessageEncoder, nil, sessionPool).(*agentImpl)
+	ag := newAgent(mockConn, nil, mockEncoder, mockSerializer, time.Second, time.Second, 0, nil, mockMessageEncoder, nil, sessionPool).(*agentImpl)
 	assert.NotNil(t, ag)
 
 	mockConn.EXPECT().RemoteAddr().Return(&mockAddr{})
@@ -702,7 +712,7 @@ func TestAgentGetStatus(t *testing.T) {
 			mockSerializer.EXPECT().GetName()
 
 			sessionPool := session.NewSessionPool()
-			ag := newAgent(mockConn, nil, mockEncoder, mockSerializer, time.Second, 0, nil, mockMessageEncoder, nil, sessionPool).(*agentImpl)
+			ag := newAgent(mockConn, nil, mockEncoder, mockSerializer, time.Second, time.Second, 0, nil, mockMessageEncoder, nil, sessionPool).(*agentImpl)
 			assert.NotNil(t, ag)
 
 			ag.state = table.status
@@ -724,7 +734,7 @@ func TestAgentSetLastAt(t *testing.T) {
 	mockSerializer.EXPECT().GetName()
 
 	sessionPool := session.NewSessionPool()
-	ag := newAgent(nil, nil, mockEncoder, mockSerializer, time.Second, 0, nil, mockMessageEncoder, nil, sessionPool).(*agentImpl)
+	ag := newAgent(nil, nil, mockEncoder, mockSerializer, time.Second, time.Second, 0, nil, mockMessageEncoder, nil, sessionPool).(*agentImpl)
 	assert.NotNil(t, ag)
 
 	ag.lastAt = 0
@@ -753,7 +763,7 @@ func TestAgentSetStatus(t *testing.T) {
 			mockSerializer.EXPECT().GetName()
 
 			sessionPool := session.NewSessionPool()
-			ag := newAgent(nil, nil, mockEncoder, mockSerializer, time.Second, 0, nil, mockMessageEncoder, nil, sessionPool).(*agentImpl)
+			ag := newAgent(nil, nil, mockEncoder, mockSerializer, time.Second, time.Second, 0, nil, mockMessageEncoder, nil, sessionPool).(*agentImpl)
 			assert.NotNil(t, ag)
 
 			ag.SetStatus(table.status)
@@ -771,7 +781,7 @@ func TestOnSessionClosed(t *testing.T) {
 	mockSerializer := serializemocks.NewMockSerializer(ctrl)
 	mockSerializer.EXPECT().GetName()
 	sessionPool := session.NewSessionPool()
-	ag := newAgent(nil, nil, mockEncoder, mockSerializer, time.Second, 0, nil, mockMessageEncoder, nil, sessionPool).(*agentImpl)
+	ag := newAgent(nil, nil, mockEncoder, mockSerializer, time.Second, time.Second, 0, nil, mockMessageEncoder, nil, sessionPool).(*agentImpl)
 
 	ss := sessionPool.NewSession(nil, true)
 
@@ -793,7 +803,7 @@ func TestOnSessionClosedRecoversIfPanic(t *testing.T) {
 	mockSerializer := serializemocks.NewMockSerializer(ctrl)
 	mockSerializer.EXPECT().GetName()
 	sessionPool := session.NewSessionPool()
-	ag := newAgent(nil, nil, mockEncoder, mockSerializer, time.Second, 0, nil, mockMessageEncoder, nil, sessionPool).(*agentImpl)
+	ag := newAgent(nil, nil, mockEncoder, mockSerializer, time.Second, time.Second, 0, nil, mockMessageEncoder, nil, sessionPool).(*agentImpl)
 
 	ss := sessionPool.NewSession(nil, true)
 
@@ -831,7 +841,7 @@ func TestAgentSendHandshakeResponse(t *testing.T) {
 			mockSerializer.EXPECT().GetName()
 
 			sessionPool := session.NewSessionPool()
-			ag := newAgent(mockConn, nil, mockEncoder, mockSerializer, time.Second, 0, nil, mockMessageEncoder, nil, sessionPool)
+			ag := newAgent(mockConn, nil, mockEncoder, mockSerializer, time.Second, time.Second, 0, nil, mockMessageEncoder, nil, sessionPool)
 			assert.NotNil(t, ag)
 
 			mockConn.EXPECT().Write(hrd).Return(0, table.err)
@@ -884,7 +894,7 @@ func TestAnswerWithError(t *testing.T) {
 			messageEncoder := message.NewMessagesEncoder(false)
 			mockSerializer.EXPECT().GetName()
 			sessionPool := session.NewSessionPool()
-			ag := newAgent(nil, nil, mockEncoder, mockSerializer, time.Second, 1, nil, messageEncoder, nil, sessionPool).(*agentImpl)
+			ag := newAgent(nil, nil, mockEncoder, mockSerializer, time.Second, time.Second, 1, nil, messageEncoder, nil, sessionPool).(*agentImpl)
 			assert.NotNil(t, ag)
 
 			mockSerializer.EXPECT().Marshal(gomock.Any()).Return(nil, row.getPayloadErr).AnyTimes()
@@ -967,7 +977,7 @@ func TestAgentAnswerWithError(t *testing.T) {
 
 			messageEncoder := message.NewMessagesEncoder(false)
 			sessionPool := session.NewSessionPool()
-			ag := newAgent(nil, nil, encoder, row.serializer, time.Second, 1, nil, messageEncoder, nil, sessionPool).(*agentImpl)
+			ag := newAgent(nil, nil, encoder, row.serializer, time.Second, time.Second, 1, nil, messageEncoder, nil, sessionPool).(*agentImpl)
 			assert.NotNil(t, ag)
 
 			ag.AnswerWithError(nil, uint(rand.Int()), row.answeredErr)
@@ -989,7 +999,7 @@ func TestAgentHeartbeat(t *testing.T) {
 	mockMessageEncoder := messagemocks.NewMockEncoder(ctrl)
 	mockSerializer.EXPECT().GetName()
 	sessionPool := session.NewSessionPool()
-	ag := newAgent(mockConn, nil, mockEncoder, mockSerializer, 1*time.Second, 1, nil, mockMessageEncoder, nil, sessionPool).(*agentImpl)
+	ag := newAgent(mockConn, nil, mockEncoder, mockSerializer, 1*time.Second, time.Second, 1, nil, mockMessageEncoder, nil, sessionPool).(*agentImpl)
 	assert.NotNil(t, ag)
 
 	mockConn.EXPECT().RemoteAddr().MaxTimes(1)
@@ -1024,7 +1034,7 @@ func TestAgentHeartbeatExitsIfConnError(t *testing.T) {
 	mockMessageEncoder := messagemocks.NewMockEncoder(ctrl)
 	mockSerializer.EXPECT().GetName()
 	sessionPool := session.NewSessionPool()
-	ag := newAgent(mockConn, nil, mockEncoder, mockSerializer, 1*time.Second, 1, nil, mockMessageEncoder, nil, sessionPool).(*agentImpl)
+	ag := newAgent(mockConn, nil, mockEncoder, mockSerializer, 1*time.Second, time.Second, 1, nil, mockMessageEncoder, nil, sessionPool).(*agentImpl)
 	assert.NotNil(t, ag)
 
 	mockConn.EXPECT().RemoteAddr().MaxTimes(1)
@@ -1064,7 +1074,7 @@ func TestAgentHeartbeatExitsOnStopHeartbeat(t *testing.T) {
 
 	mockSerializer.EXPECT().GetName()
 	sessionPool := session.NewSessionPool()
-	ag := newAgent(mockConn, nil, mockEncoder, mockSerializer, 1*time.Second, 1, nil, messageEncoder, nil, sessionPool).(*agentImpl)
+	ag := newAgent(mockConn, nil, mockEncoder, mockSerializer, 1*time.Second, time.Second, 1, nil, messageEncoder, nil, sessionPool).(*agentImpl)
 	assert.NotNil(t, ag)
 
 	go func() {
@@ -1094,6 +1104,7 @@ func TestAgentWriteChSend(t *testing.T) {
 		serializer:       mockSerializer,
 		messageEncoder:   messageEncoder,
 		metricsReporters: mockMetricsReporters,
+		writeTimeout:     time.Second,
 	}
 	ctx := getCtxWithRequestKeys()
 	mockMetricsReporters[0].(*metricsmocks.MockReporter).EXPECT().ReportSummary(metrics.ResponseTime, gomock.Any(), gomock.Any())
@@ -1103,6 +1114,7 @@ func TestAgentWriteChSend(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 	mockConn.EXPECT().RemoteAddr().Times(2).Return(&mockAddr{})
+	mockConn.EXPECT().SetWriteDeadline(gomock.Any()).Return(nil)
 	mockConn.EXPECT().Write(expectedPacket).Do(func(b []byte) {
 		time.Sleep(10 * time.Millisecond)
 		wg.Done()
@@ -1123,7 +1135,7 @@ func TestAgentHandle(t *testing.T) {
 	messageEncoder := message.NewMessagesEncoder(false)
 	mockSerializer.EXPECT().GetName()
 	sessionPool := session.NewSessionPool()
-	ag := newAgent(mockConn, nil, mockEncoder, mockSerializer, 1*time.Second, 1, nil, messageEncoder, nil, sessionPool).(*agentImpl)
+	ag := newAgent(mockConn, nil, mockEncoder, mockSerializer, 1*time.Second, time.Second, 1, nil, messageEncoder, nil, sessionPool).(*agentImpl)
 	assert.NotNil(t, ag)
 
 	expectedBytes := []byte("bla")
@@ -1142,6 +1154,7 @@ func TestAgentHandle(t *testing.T) {
 		}
 	}()
 
+	mockConn.EXPECT().SetWriteDeadline(gomock.Any()).Return(nil).Times(3)
 	mockConn.EXPECT().Write(expectedBytes).Return(0, nil).Do(func(d []byte) {
 		wg.Done()
 	})
@@ -1168,6 +1181,7 @@ func TestNatsRPCServerReportMetrics(t *testing.T) {
 	mockDecoder := codecmocks.NewMockPacketDecoder(ctrl)
 	dieChan := make(chan bool)
 	hbTime := time.Second
+	writeTimeout := time.Second
 	messageEncoder := message.NewMessagesEncoder(false)
 	mockMetricsReporter := metricsmocks.NewMockReporter(ctrl)
 	mockMetricsReporters := []metrics.Reporter{mockMetricsReporter}
@@ -1175,7 +1189,7 @@ func TestNatsRPCServerReportMetrics(t *testing.T) {
 	mockMetricsReporter.EXPECT().ReportGauge(metrics.ConnectedClients, gomock.Any(), gomock.Any())
 	mockSerializer.EXPECT().GetName()
 	sessionPool := session.NewSessionPool()
-	ag := newAgent(mockConn, mockDecoder, mockEncoder, mockSerializer, hbTime, 10, dieChan, messageEncoder, mockMetricsReporters, sessionPool).(*agentImpl)
+	ag := newAgent(mockConn, mockDecoder, mockEncoder, mockSerializer, hbTime, writeTimeout, 10, dieChan, messageEncoder, mockMetricsReporters, sessionPool).(*agentImpl)
 	assert.NotNil(t, ag)
 
 	ag.messagesBufferSize = 0
@@ -1233,7 +1247,7 @@ func TestAgentWriteChSendWriteError(t *testing.T) {
 	mockMetricsReporters := []metrics.Reporter{mockMetricsReporter}
 	sessionPool := session.NewSessionPool()
 
-	ag := newAgent(mockConn, nil, mockEncoder, mockSerializer, time.Second, 0, nil, messageEncoder, mockMetricsReporters, sessionPool).(*agentImpl)
+	ag := newAgent(mockConn, nil, mockEncoder, mockSerializer, time.Second, time.Second, 0, nil, messageEncoder, mockMetricsReporters, sessionPool).(*agentImpl)
 
 	ctx := getCtxWithRequestKeys()
 
@@ -1257,11 +1271,59 @@ func TestAgentWriteChSendWriteError(t *testing.T) {
 	mockConn.EXPECT().Close().Do(func() {
 		wg.Done()
 	})
+	mockConn.EXPECT().SetWriteDeadline(gomock.Any()).Return(nil)
 	mockConn.EXPECT().Write(expectedPacket).Do(func(b []byte) {
 		wg.Done()
 	}).Return(0, writeError)
 
 	go ag.write()
 	ag.chSend <- pendingWrite{ctx: ctx, data: expectedPacket, err: nil}
+	wg.Wait()
+}
+
+func TestAgentWriteChSendWriteTimeout(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockSerializer := serializemocks.NewMockSerializer(ctrl)
+	mockSerializer.EXPECT().GetName()
+
+	mockEncoder := codecmocks.NewMockPacketEncoder(ctrl)
+	mockConn := mocks.NewMockPlayerConn(ctrl)
+	messageEncoder := message.NewMessagesEncoder(false)
+	mockMetricsReporter := metricsmocks.NewMockReporter(ctrl)
+	mockMetricsReporter.EXPECT().ReportGauge(metrics.ConnectedClients, gomock.Any(), gomock.Any())
+
+	mockMetricsReporters := []metrics.Reporter{mockMetricsReporter}
+	sessionPool := session.NewSessionPool()
+
+	writeTimeout := 10 * time.Millisecond
+
+	ag := newAgent(mockConn, nil, mockEncoder, mockSerializer, time.Second, writeTimeout, 0, nil, messageEncoder, mockMetricsReporters, sessionPool).(*agentImpl)
+
+	ctx := getCtxWithRequestKeys()
+
+	expectedFirstPacket := []byte("first")
+	expectedSecondPacket := []byte("final")
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	mockMetricsReporter.EXPECT().ReportSummary(metrics.ResponseTime, gomock.Any(), gomock.Any()).Times(2)
+
+	mockConn.EXPECT().RemoteAddr().Return(&mockAddr{}).Times(4)
+	mockConn.EXPECT().SetWriteDeadline(gomock.Any()).Return(nil).Times(2)
+	mockConn.EXPECT().Write(expectedFirstPacket).Do(func(b []byte) {
+		time.Sleep(writeTimeout * 2)
+		wg.Done()
+	}).Return(0, os.ErrDeadlineExceeded)
+
+	mockConn.EXPECT().Write(expectedSecondPacket).Do(func(b []byte) {
+		wg.Done()
+	}).Return(0, nil)
+
+	go ag.write()
+	ag.chSend <- pendingWrite{ctx: ctx, data: expectedFirstPacket, err: nil}
+	ag.chSend <- pendingWrite{ctx: ctx, data: expectedSecondPacket, err: nil}
 	wg.Wait()
 }

--- a/builder.go
+++ b/builder.go
@@ -222,6 +222,7 @@ func (builder *Builder) Build() Pitaya {
 		builder.PacketEncoder,
 		builder.Serializer,
 		builder.Config.Heartbeat.Interval,
+		builder.Config.Buffer.Agent.WriteTimeout,
 		builder.MessageEncoder,
 		builder.Config.Buffer.Agent.Messages,
 		builder.SessionPool,

--- a/config/config.go
+++ b/config/config.go
@@ -6,6 +6,8 @@ import (
 	"github.com/topfreegames/pitaya/v2/metrics/models"
 )
 
+const DefaultWriteTimeout = 10 * time.Second
+
 // PitayaConfig provides all the configuration for a pitaya app
 type PitayaConfig struct {
 	SerializerType   uint16 `mapstructure:"serializertype"`
@@ -25,7 +27,8 @@ type PitayaConfig struct {
 	} `mapstructure:"handler"`
 	Buffer struct {
 		Agent struct {
-			Messages int `mapstructure:"messages"`
+			Messages     int           `mapstructure:"messages"`
+			WriteTimeout time.Duration `mapstructure:"conntimeout"`
 		} `mapstructure:"agent"`
 		Handler struct {
 			LocalProcess  int `mapstructure:"localprocess"`
@@ -91,7 +94,8 @@ func NewDefaultPitayaConfig() *PitayaConfig {
 		},
 		Buffer: struct {
 			Agent struct {
-				Messages int `mapstructure:"messages"`
+				Messages     int           `mapstructure:"messages"`
+				WriteTimeout time.Duration `mapstructure:"conntimeout"`
 			} `mapstructure:"agent"`
 			Handler struct {
 				LocalProcess  int `mapstructure:"localprocess"`
@@ -99,9 +103,11 @@ func NewDefaultPitayaConfig() *PitayaConfig {
 			} `mapstructure:"handler"`
 		}{
 			Agent: struct {
-				Messages int `mapstructure:"messages"`
+				Messages     int           `mapstructure:"messages"`
+				WriteTimeout time.Duration `mapstructure:"conntimeout"`
 			}{
-				Messages: 100,
+				Messages:     100,
+				WriteTimeout: DefaultWriteTimeout,
 			},
 			Handler: struct {
 				LocalProcess  int `mapstructure:"localprocess"`

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -223,6 +223,10 @@ Connection
     - 30s
     - time.Time
     - Keepalive heartbeat interval for the client connection
+  * - pitaya.buffer.agent.writetimeout
+    - 10s
+    - time.Duration
+    - Timeout for agent to send packets
   * - pitaya.conn.ratelimiting.interval
     - 1s
     - time.Duration


### PR DESCRIPTION
When sending a message via agent, the write connection does not have a default timeout, leading to blocking calls if the connections is unhealthy or simply a bad route to it. Thus, adding a write timeout to the writes so we fail but don't block. If deadline is exceeded then we log an error but don't close a connection, since it might fail due to bad route but not a broken pipe per-se. The new configuration can be found under: `pitaya.buffer.agent.writetimeout`, with 10s by default.

The timeout is set using `SetWriteDeadline` function from go net pkg: https://pkg.go.dev/net#Conn