### PR TITLE
[V2] refactor(agent): channel capacity as histogram

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -696,7 +696,10 @@ func (a *agentImpl) reportChannelSize() {
 	}
 	for _, mr := range a.metricsReporters {
 		if err := mr.ReportGauge(metrics.ChannelCapacity, map[string]string{"channel": "agent_chsend"}, float64(chSendCapacity)); err != nil {
-			logger.Log.Warnf("failed to report chSend channel capaacity: %s", err.Error())
+			logger.Log.Warnf("failed to report gauge chSend channel capacity: %s", err.Error())
+		}
+		if err := mr.ReportHistogram(metrics.ChannelCapacityHistogram, map[string]string{"channel": "agent_chsend"}, float64(chSendCapacity)); err != nil {
+			logger.Log.Warnf("failed to report histogram chSend channel capacity: %s", err.Error())
 		}
 	}
 }

--- a/metrics/constants.go
+++ b/metrics/constants.go
@@ -8,7 +8,10 @@ var (
 	// CountServers counts the number of servers of different types
 	CountServers = "count_servers"
 	// ChannelCapacity represents the capacity of a channel (available slots)
+	// Deprecated: This variable will be removed in future versions. Use ChannelCapacityHistogram instead.
 	ChannelCapacity = "channel_capacity"
+	// ChannelCapacityHistogram represents the capacity of a channel as a histogram (distribution of available slots)
+	ChannelCapacityHistogram = "channel_capacity_histogram"
 	// DroppedMessages reports the number of dropped messages in rpc server (messages that will not be handled)
 	DroppedMessages = "dropped_messages"
 	// ProcessDelay reports the message processing delay to handle the messages at the handler service

--- a/metrics/prometheus_reporter.go
+++ b/metrics/prometheus_reporter.go
@@ -199,6 +199,17 @@ func (p *PrometheusReporter) registerMetrics(
 		append([]string{"channel"}, additionalLabelsKeys...),
 	)
 
+	p.histogramReportersMap[ChannelCapacityHistogram] = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace:   "pitaya",
+			Subsystem:   "channel",
+			Name:        ChannelCapacityHistogram,
+			Help:        "the available capacity of the channel",
+			Buckets:     []float64{0, 1, 10, 50, 100, 250, 500, 750, 1000, 1500, 2000, 3000, 4000, 5000},
+			ConstLabels: constLabels,
+		},
+		append([]string{"channel"}, additionalLabelsKeys...),
+
 	p.gaugeReportersMap[DroppedMessages] = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace:   "pitaya",


### PR DESCRIPTION
# Problem

Connectors with agents reaching 0 capacity but metric still report as full capacity

# Reason

Channel capacity is a metric of each agent, that is created in each handle so the capacity varies depending on the client/agent being used and we need to differentiate the lows/highs of each in the metric.

# Solution

Adding a client label to the Gauge is not feasible, since it'd explode cardinality. Thus, adding a new metric to be an Histogram so we can capture the highs and lows. The old one will be deprecated one we migrate all graphs to use the new one