### PR TITLE
Port connection info changes to v2

### DIFF
--- a/app.go
+++ b/app.go
@@ -125,6 +125,8 @@ type Pitaya interface {
 	RegisterModuleAfter(module interfaces.Module, name string) error
 	RegisterModuleBefore(module interfaces.Module, name string) error
 	GetModule(name string) (interfaces.Module, error)
+
+	GetNumberOfConnectedClients() int64
 }
 
 // App is the base app struct
@@ -552,4 +554,9 @@ func (app *App) StartWorker() {
 func (app *App) RegisterRPCJob(rpcJob worker.RPCJob) error {
 	err := app.worker.RegisterRPCJob(rpcJob)
 	return err
+}
+
+// GetNumberOfConnectedClients returns the number of connected clients
+func (app *App) GetNumberOfConnectedClients() int64 {
+	return app.sessionPool.GetSessionCount()
 }

--- a/mocks/app.go
+++ b/mocks/app.go
@@ -116,6 +116,20 @@ func (mr *MockPitayaMockRecorder) GetModule(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetModule", reflect.TypeOf((*MockPitaya)(nil).GetModule), arg0)
 }
 
+// GetNumberOfConnectedClients mocks base method.
+func (m *MockPitaya) GetNumberOfConnectedClients() int64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNumberOfConnectedClients")
+	ret0, _ := ret[0].(int64)
+	return ret0
+}
+
+// GetNumberOfConnectedClients indicates an expected call of GetNumberOfConnectedClients.
+func (mr *MockPitayaMockRecorder) GetNumberOfConnectedClients() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNumberOfConnectedClients", reflect.TypeOf((*MockPitaya)(nil).GetNumberOfConnectedClients))
+}
+
 // GetServer mocks base method.
 func (m *MockPitaya) GetServer() *cluster.Server {
 	m.ctrl.T.Helper()

--- a/session/mocks/session.go
+++ b/session/mocks/session.go
@@ -732,6 +732,20 @@ func (mr *MockSessionPoolMockRecorder) CloseAll() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloseAll", reflect.TypeOf((*MockSessionPool)(nil).CloseAll))
 }
 
+// GetNumberOfConnectedClients mocks base method.
+func (m *MockSessionPool) GetNumberOfConnectedClients() int64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNumberOfConnectedClients")
+	ret0, _ := ret[0].(int64)
+	return ret0
+}
+
+// GetNumberOfConnectedClients indicates an expected call of GetNumberOfConnectedClients.
+func (mr *MockSessionPoolMockRecorder) GetNumberOfConnectedClients() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNumberOfConnectedClients", reflect.TypeOf((*MockSessionPool)(nil).GetNumberOfConnectedClients))
+}
+
 // GetSessionByID mocks base method.
 func (m *MockSessionPool) GetSessionByID(arg0 int64) session.Session {
 	m.ctrl.T.Helper()

--- a/session/session.go
+++ b/session/session.go
@@ -64,6 +64,7 @@ type SessionPool interface {
 	OnSessionClose(f func(s Session))
 	CloseAll()
 	AddHandshakeValidator(name string, f func(data *HandshakeData) error)
+	GetNumberOfConnectedClients() int64
 }
 
 // HandshakeClientData represents information about the client sent on the handshake.
@@ -308,6 +309,11 @@ func (pool *sessionPoolImpl) CloseAll() {
 // handshake packets are processed. Errors will be raised with the given name.
 func (pool *sessionPoolImpl) AddHandshakeValidator(name string, f func(data *HandshakeData) error) {
 	pool.handshakeValidators[name] = f
+}
+
+// GetNumberOfConnectedClients returns the number of connected clients
+func (pool *sessionPoolImpl) GetNumberOfConnectedClients() int64 {
+	return pool.GetSessionCount()
 }
 
 func (s *sessionImpl) updateEncodedData() error {

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -1507,3 +1507,18 @@ func TestSessionValidateHandshake(t *testing.T) {
 		})
 	}
 }
+
+func TestGetNumberOfConnectedClients(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	entity := mocks.NewMockNetworkEntity(ctrl)
+	sessionPool := NewSessionPool()
+	connections := sessionPool.GetNumberOfConnectedClients()
+	assert.Equal(t, int64(0), connections)
+
+	ss := sessionPool.NewSession(entity, true)
+	assert.NotNil(t, ss)
+	connections = sessionPool.GetNumberOfConnectedClients()
+	assert.Equal(t, int64(1), connections)
+}

--- a/session/static.go
+++ b/session/static.go
@@ -39,5 +39,5 @@ func CloseAll() {
 
 // GetNumberOfConnectedClients returns the number of connected clients
 func GetNumberOfConnectedClients() int64 {
-	return DefaultSessionPool.GetSessionCount()
+	return DefaultSessionPool.GetNumberOfConnectedClients()
 }

--- a/session/static.go
+++ b/session/static.go
@@ -36,3 +36,8 @@ func OnSessionClose(f func(s Session)) {
 func CloseAll() {
 	DefaultSessionPool.CloseAll()
 }
+
+// GetNumberOfConnectedClients returns the number of connected clients
+func GetNumberOfConnectedClients() int64 {
+	return DefaultSessionPool.GetSessionCount()
+}

--- a/session/test/static_test.go
+++ b/session/test/static_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"math"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -114,4 +115,16 @@ func TestStaticCloseAll(t *testing.T) {
 
 	session.DefaultSessionPool = sessionPool
 	session.CloseAll()
+}
+
+func TestGetNumberOfConnectedClients(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	expected := int64(math.MaxInt64)
+	sessionPool := mocks.NewMockSessionPool(ctrl)
+	sessionPool.EXPECT().GetNumberOfConnectedClients().Return(expected)
+
+	session.DefaultSessionPool = sessionPool
+	numberOfConnections := session.GetNumberOfConnectedClients()
+	require.Equal(t, expected, numberOfConnections)
 }

--- a/static.go
+++ b/static.go
@@ -225,3 +225,7 @@ func RegisterModuleBefore(module interfaces.Module, name string) error {
 func GetModule(name string) (interfaces.Module, error) {
 	return DefaultApp.GetModule(name)
 }
+
+func GetNumberOfConnectedClients() int64 {
+	return DefaultApp.GetNumberOfConnectedClients()
+}

--- a/static_test.go
+++ b/static_test.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"errors"
 	"github.com/topfreegames/pitaya/v2/constants"
+	"math"
 	"testing"
 	"time"
 
@@ -921,4 +922,16 @@ func TestStaticGetModule(t *testing.T) {
 			require.Equal(t, row.module, module)
 		})
 	}
+}
+
+func TestGetNumberOfConnectedClients(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	expected := int64(math.MaxInt64)
+
+	app := mocks.NewMockPitaya(ctrl)
+	app.EXPECT().GetNumberOfConnectedClients().Return(expected)
+
+	DefaultApp = app
+	require.Equal(t, expected, GetNumberOfConnectedClients())
 }


### PR DESCRIPTION
Couple of changes were added to v2.9.1, v2.9.2 and v2.9.3 that we need to port to the mainline of v2:
* #430 
* #431 

## Summary

Get number of connected clients and expose this via API