### PR TITLE
fix(nats): wait for reconnects on setup

### DIFF
--- a/pkg/app.go
+++ b/pkg/app.go
@@ -324,8 +324,8 @@ func (app *App) Start() {
 		app.running = false
 	}()
 
-	sg := make(chan os.Signal)
-	signal.Notify(sg, syscall.SIGINT, syscall.SIGQUIT, syscall.SIGKILL, syscall.SIGTERM)
+	sg := make(chan os.Signal, 1)
+	signal.Notify(sg, syscall.SIGINT, syscall.SIGQUIT, syscall.SIGTERM)
 
 	maxSessionCount := func() int64 {
 		count := app.sessionPool.GetSessionCount()

--- a/pkg/cluster/etcd_service_discovery.go
+++ b/pkg/cluster/etcd_service_discovery.go
@@ -27,12 +27,13 @@ import (
 	"strings"
 	"sync"
 	"time"
+
 	"github.com/topfreegames/pitaya/v3/pkg/config"
 	"github.com/topfreegames/pitaya/v3/pkg/constants"
 	"github.com/topfreegames/pitaya/v3/pkg/logger"
 	"github.com/topfreegames/pitaya/v3/pkg/util"
-	clientv3 "go.etcd.io/etcd/client/v3"
 	logutil "go.etcd.io/etcd/client/pkg/v3/logutil"
+	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/client/v3/namespace"
 	"google.golang.org/grpc"
 )
@@ -81,14 +82,14 @@ func NewEtcdServiceDiscovery(
 		client = cli[0]
 	}
 	sd := &etcdServiceDiscovery{
-		running:         false,
-		server:          server,
-		serverMapByType: make(map[string]map[string]*Server),
-		listeners:       make([]SDListener, 0),
-		stopChan:        make(chan bool),
-		stopLeaseChan:   make(chan bool),
-		appDieChan:      appDieChan,
-		cli:             client,
+		running:            false,
+		server:             server,
+		serverMapByType:    make(map[string]map[string]*Server),
+		listeners:          make([]SDListener, 0),
+		stopChan:           make(chan bool),
+		stopLeaseChan:      make(chan bool),
+		appDieChan:         appDieChan,
+		cli:                client,
 		syncServersRunning: make(chan bool),
 	}
 
@@ -300,7 +301,7 @@ func (sd *etcdServiceDiscovery) GetServersByType(serverType string) (map[string]
 		// Create a new map to avoid concurrent read and write access to the
 		// map, this also prevents accidental changes to the list of servers
 		// kept by the service discovery.
-		ret := make(map[string]*Server,len(sd.serverMapByType[serverType]))
+		ret := make(map[string]*Server, len(sd.serverMapByType[serverType]))
 		for k, v := range sd.serverMapByType[serverType] {
 			ret[k] = v
 		}
@@ -615,8 +616,12 @@ func (sd *etcdServiceDiscovery) revoke() error {
 	go func() {
 		defer close(c)
 		logger.Log.Debug("waiting for etcd revoke")
-		_, err := sd.cli.Revoke(context.TODO(), sd.leaseID)
-		c <- err
+		if sd.cli != nil {
+			_, err := sd.cli.Revoke(context.TODO(), sd.leaseID)
+			c <- err
+		} else {
+			c <- nil
+		}
 		logger.Log.Debug("finished waiting for etcd revoke")
 	}()
 	select {

--- a/pkg/cluster/grpc_rpc_server_test.go
+++ b/pkg/cluster/grpc_rpc_server_test.go
@@ -32,6 +32,7 @@ func TestGRPCServerInit(t *testing.T) {
 
 	sv := getServer()
 	gs, err := NewGRPCServer(c, sv, []metrics.Reporter{})
+	assert.NoError(t, err)
 	gs.SetPitayaServer(mockPitayaServer)
 	err = gs.Init()
 	assert.NoError(t, err)


### PR DESCRIPTION
Ported from v2 #439 

If the initial connect fails, NATS will spawn reconnect async handlers. Thus, we need to wait for all reconnects to be attempted before returning to the caller, otherwise, we won't be making use of reconnections.

* fix(app): init sig chan as buffered
* fix(etcd): prevent shutdown from crashing app

If the etcd module shuts down before all connections are set up, it will crash trying to access sd.cli where it's still nil. Thus, adding a check on shutdown