### PR TITLE
fix(nats): cross-platform signal handling

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.22'
+        go-version: '1.23'
     - name: Download dependencies
       run: go mod download
   unit-test:
@@ -33,7 +33,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.22'
+        go-version: '1.23'
     - name: Setup dependencies
       env:
         GO111MODULE: auto
@@ -54,7 +54,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.22'
+        go-version: '1.23'
     - name: Run tests
       run: make e2e-test-nats
   e2e-test-grpc:
@@ -67,6 +67,6 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.22'
+        go-version: '1.23'
     - name: Run tests
       run: make e2e-test-grpc


### PR DESCRIPTION
When nats fails to connect and there are no termination channels available, we need to stop the application using platform signals. To make it cross-paltform, we must ensure to send os.Interrupt so it works on both Unix and Windows machines

- Closes #445 