### PR TITLE
Fix dieChan not getting closed or pitaya not terminating on fatal etcd and nats failures

### DIFF
--- a/app.go
+++ b/app.go
@@ -70,6 +70,8 @@ const (
 
 // Pitaya App interface
 type Pitaya interface {
+	// GetDieChan gets the channel that the app sinalizes when its going to die. Note that listening to this channel
+	// might swallow internal signals, so it's recommended to wait for Start to return or invoke Shutdown when terminating the application.
 	GetDieChan() chan bool
 	SetDebug(debug bool)
 	SetHeartbeatTime(interval time.Duration)
@@ -212,7 +214,8 @@ func NewApp(
 	return app
 }
 
-// GetDieChan gets the channel that the app sinalizes when its going to die
+// GetDieChan gets the channel that the app sinalizes when its going to die. Note that listening to this channel
+// might swallow internal signals, so it's recommended to wait for Start to return or invoke Shutdown when terminating the application.
 func (app *App) GetDieChan() chan bool {
 	return app.dieChan
 }
@@ -340,6 +343,7 @@ func (app *App) Start() {
 	select {
 	case <-app.dieChan:
 		logger.Log.Warn("the app will shutdown in a few seconds")
+		close(app.dieChan)
 	case s := <-sg:
 		logger.Log.Warn("got signal: ", s, ", shutting down...")
 		if app.config.Session.Drain.Enabled && s == syscall.SIGTERM {

--- a/app.go
+++ b/app.go
@@ -344,7 +344,6 @@ func (app *App) Start() {
 	select {
 	case <-app.dieChan:
 		logger.Log.Warn("the app will shutdown in a few seconds")
-		close(app.dieChan)
 	case s := <-app.sgChan:
 		logger.Log.Warn("got signal: ", s, ", shutting down...")
 		if app.config.Session.Drain.Enabled && s == syscall.SIGTERM {
@@ -372,9 +371,9 @@ func (app *App) Start() {
 				}
 			}
 		}
-		close(app.dieChan)
 	}
 
+	app.Shutdown()
 	close(app.externalDieChan)
 	close(app.sgChan)
 

--- a/app_test.go
+++ b/app_test.go
@@ -205,7 +205,7 @@ func TestShutdown(t *testing.T) {
 
 func TestShutdown_ShouldSucceedOnStartedApp(t *testing.T) {
 	builderConfig := config.NewDefaultPitayaConfig()
-	app := NewDefaultApp(false, "testtype", Cluster, map[string]string{}, *builderConfig).(*App)
+	app := NewDefaultApp(false, "testtype", Standalone, map[string]string{}, *builderConfig).(*App)
 
 	var wait sync.WaitGroup
 	wait.Add(1)
@@ -264,7 +264,7 @@ func TestGetDieChan_ShouldNotHangOnTerminationIfListenedByApp(t *testing.T) {
 func TestShutdown_ShouldSucceedOnDrainingApp(t *testing.T) {
 	builderConfig := config.NewDefaultPitayaConfig()
 	builderConfig.Session.Drain.Enabled = true
-	app := NewDefaultApp(false, "testtype", Cluster, map[string]string{}, *builderConfig).(*App)
+	app := NewDefaultApp(false, "testtype", Standalone, map[string]string{}, *builderConfig).(*App)
 
 	var wait sync.WaitGroup
 	wait.Add(1)

--- a/app_test.go
+++ b/app_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/topfreegames/pitaya/v2/constants"
 	e "github.com/topfreegames/pitaya/v2/errors"
 	"github.com/topfreegames/pitaya/v2/helpers"
+	"github.com/topfreegames/pitaya/v2/internal/testing/assertions"
 	"github.com/topfreegames/pitaya/v2/logger"
 	"github.com/topfreegames/pitaya/v2/logger/logrus"
 	"github.com/topfreegames/pitaya/v2/route"
@@ -204,6 +205,19 @@ func TestShutdown(t *testing.T) {
 		app.Shutdown()
 	}()
 	<-app.dieChan
+}
+
+func TestDieChan_ShouldCloseWhenMessageIsSent(t *testing.T) {
+	builderConfig := config.NewDefaultPitayaConfig()
+	app := NewDefaultApp(false, "testtype", Standalone, map[string]string{}, *builderConfig).(*App)
+
+	go func() {
+		app.Start()
+	}()
+
+	app.dieChan <- true
+
+	assertions.ShouldEventuallyClose(t, app.dieChan, 1*time.Second)
 }
 
 func TestConfigureDefaultMetricsReporter(t *testing.T) {

--- a/internal/testing/assertions/assert.go
+++ b/internal/testing/assertions/assert.go
@@ -1,11 +1,26 @@
 package assertions
 
 import (
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func ShouldEventuallyReturn(t testing.TB, wg *sync.WaitGroup, timeout time.Duration) {
+	c := make(chan struct{})
+	go func() {
+		defer close(c)
+		wg.Wait()
+	}()
+	select {
+	case <-c:
+		return
+	case <-time.After(timeout):
+		assert.Fail(t, "timed out waiting for sync.WaitGroup to finish")
+	}
+}
 
 func ShouldEventuallyClose(t testing.TB, channel chan bool, timeout time.Duration) {
 	c := make(chan struct{})

--- a/internal/testing/assertions/assert.go
+++ b/internal/testing/assertions/assert.go
@@ -1,0 +1,19 @@
+package assertions
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func ShouldEventuallyClose(t testing.TB, channel chan bool, timeout time.Duration) {
+	c := make(chan struct{})
+	select {
+	case <-channel:
+		close(c)
+		return
+	case <-time.After(timeout):
+		assert.Fail(t, "timed out waiting for channel to close")
+	}
+}

--- a/static.go
+++ b/static.go
@@ -58,6 +58,8 @@ func Configure(
 	session.DefaultSessionPool = builder.SessionPool
 }
 
+// GetDieChan gets the channel that the app sinalizes when its going to die. Note that listening to this channel
+// might swallow internal signals, so it's recommended to wait for Start to return or invoke Shutdown when terminating the application.
 func GetDieChan() chan bool {
 	return DefaultApp.GetDieChan()
 }

--- a/static.go
+++ b/static.go
@@ -58,8 +58,7 @@ func Configure(
 	session.DefaultSessionPool = builder.SessionPool
 }
 
-// GetDieChan gets the channel that the app sinalizes when its going to die. Note that listening to this channel
-// might swallow internal signals, so it's recommended to wait for Start to return or invoke Shutdown when terminating the application.
+// GetDieChan gets the channel that the app sinalizes when its going to die.
 func GetDieChan() chan bool {
 	return DefaultApp.GetDieChan()
 }


### PR DESCRIPTION
This issue could cause pitaya to get into a zombie state in case of fatal etcd or nats failure.

Some applications usually listen to this channel with `GetDieChan()` in order to handle pitaya's termination. In these cases, pitaya would run its termination flow by disposing modules and components, but the channel would never return for the application, leading to the zombie state.

Another problem is that using `GetDieChan()` and listening to it in the application side can swallow the internal termination message. This in turn leads to pitaya never entering the termination flow and the application getting stuck waiting for `Start()` to return.

Example of fragile usage that can trigger both issues currently ❌:
```go
func (a *App) Start() {
	dieChan := a.pitaya.GetDieChan()

	var wg sync.WaitGroup
	wg.Add(1)
	go func() {
		defer wg.Done()
		a.pitaya.Start()
	}()

        // wait for pitaya to start.

	fmt.Println("server started")

	<-dieChan // <---- termination might get stuck here waiting for the channel to get closed

	fmt.Println("server is terminating")

	wg.Wait() // <---- or if we get the die message from dieChan above, then we get stuck here waiting for a.pitaya.Start() to finish
}
```

The proposed pull request addresses both cases.

However, in order to fix the second one, a small behavioral API change was required (see second commit). Now, we publicly expose a proxy, one-way, channel in `GetDieChan()` that the application layer can listen to. We can't really make it two-way as we might face the same problem again.

The alternative in order to keep the public API completely untouched would be to either deprecate `GetDieChan()` completely or alway require a call to `Shutdown()`, even though pitaya might be terminating already. Here's how each approach could look like:

Using `Shutdown()`:
```go
func (a *App) Start() {
	dieChan := a.pitaya.GetDieChan()

	var wg sync.WaitGroup
	wg.Add(1)
	go func() {
		defer wg.Done()
		a.pitaya.Start()
	}()

        // wait for pitaya to start.

	fmt.Println("server started")

	<-dieChan

	a.pitaya.Shutdown() // <---- invoking Shutdown() here covers the edge case of the previous line swallowing the termination signal and preventing Start() to return

	fmt.Println("server is terminating")

	wg.Wait()
}
```

Without relying on `GetDieChan()` at all:
```go
func (a *App) Start() {
	var wg sync.WaitGroup
	wg.Add(1)
	go func() {
		defer wg.Done()
		a.pitaya.Start()
	}()

        // wait for pitaya to start.

	fmt.Println("server started")

	wg.Wait()

	fmt.Println("pitaya terminated")
}
```

And as a final note, it might be worth mentioning that my recommendation for `v3` is to remove `GetDieChan()` completely and solely rely on the last example as good API usage.