### PR TITLE
refactor(agent): channel capacity as histogram

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -699,7 +699,10 @@ func (a *agentImpl) reportChannelSize() {
 	}
 	for _, mr := range a.metricsReporters {
 		if err := mr.ReportGauge(metrics.ChannelCapacity, map[string]string{"channel": "agent_chsend"}, float64(chSendCapacity)); err != nil {
-			logger.Log.Warnf("failed to report chSend channel capaacity: %s", err.Error())
+			logger.Log.Warnf("failed to report gauge chSend channel capacity: %s", err.Error())
+		}
+		if err := mr.ReportHistogram(metrics.ChannelCapacityHistogram, map[string]string{"channel": "agent_chsend"}, float64(chSendCapacity)); err != nil {
+			logger.Log.Warnf("failed to report histogram chSend channel capacity: %s", err.Error())
 		}
 	}
 }

--- a/pkg/metrics/constants.go
+++ b/pkg/metrics/constants.go
@@ -8,7 +8,10 @@ var (
 	// CountServers counts the number of servers of different types
 	CountServers = "count_servers"
 	// ChannelCapacity represents the capacity of a channel (available slots)
+	// Deprecated: This variable will be removed in future versions. Use ChannelCapacityHistogram instead.
 	ChannelCapacity = "channel_capacity"
+	// ChannelCapacityHistogram represents the capacity of a channel as a histogram (distribution of available slots)
+	ChannelCapacityHistogram = "channel_capacity_histogram"
 	// DroppedMessages reports the number of dropped messages in rpc server (messages that will not be handled)
 	DroppedMessages = "dropped_messages"
 	// ProcessDelay reports the message processing delay to handle the messages at the handler service

--- a/pkg/metrics/prometheus_reporter.go
+++ b/pkg/metrics/prometheus_reporter.go
@@ -199,6 +199,17 @@ func (p *PrometheusReporter) registerMetrics(
 		append([]string{"channel"}, additionalLabelsKeys...),
 	)
 
+	p.histogramReportersMap[ChannelCapacityHistogram] = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace:   "pitaya",
+			Subsystem:   "channel",
+			Name:        ChannelCapacityHistogram,
+			Help:        "the available capacity of the channel",
+			Buckets:     []float64{0, 1, 10, 50, 100, 250, 500, 750, 1000, 1500, 2000, 3000, 4000, 5000},
+			ConstLabels: constLabels,
+		},
+		append([]string{"channel"}, additionalLabelsKeys...),
+
 	p.gaugeReportersMap[DroppedMessages] = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace:   "pitaya",


### PR DESCRIPTION
# Porting fix from V2 #429 

Channel capacity is a metric of each agent, that is created in each handle so the capacity varies depending on the client/agent being used and we need to differentiate the lows/highs of each in the metric. Adding a client label to the Gauge is not feasible, since it'd explode cardinality. Thus, adding a new metric as an histogram so we maintain compat until deprecating the old gauge one