### PR TITLE
fix(metrics): tests and usage in nats rpc

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -276,6 +276,7 @@ func TestAgentSendSerializeErr(t *testing.T) {
 	})
 	go ag.write()
 	mockMetricsReporter.EXPECT().ReportGauge(gomock.Any(), gomock.Any(), gomock.Any())
+	mockMetricsReporter.EXPECT().ReportHistogram(gomock.Any(), gomock.Any(), gomock.Any())
 	ag.send(expected)
 	wg.Wait()
 
@@ -348,6 +349,7 @@ func TestAgentPushStruct(t *testing.T) {
 			}
 
 			mockMetricsReporter.EXPECT().ReportGauge(metrics.ChannelCapacity, gomock.Any(), float64(10))
+			mockMetricsReporter.EXPECT().ReportHistogram(metrics.ChannelCapacityHistogram, gomock.Any(), float64(10))
 			err = ag.Push(msg.Route, table.data)
 			assert.Equal(t, table.err, err)
 
@@ -410,6 +412,7 @@ func TestAgentPush(t *testing.T) {
 			}
 
 			mockMetricsReporter.EXPECT().ReportGauge(metrics.ChannelCapacity, gomock.Any(), float64(10))
+			mockMetricsReporter.EXPECT().ReportHistogram(metrics.ChannelCapacityHistogram, gomock.Any(), float64(10))
 			err = ag.Push(msg.Route, table.data)
 			assert.Equal(t, table.err, err)
 
@@ -443,6 +446,7 @@ func TestAgentPushFullChannel(t *testing.T) {
 	assert.NotNil(t, ag)
 
 	mockMetricsReporter.EXPECT().ReportGauge(metrics.ChannelCapacity, gomock.Any(), float64(0))
+	mockMetricsReporter.EXPECT().ReportHistogram(metrics.ChannelCapacityHistogram, gomock.Any(), float64(0))
 
 	msg := &message.Message{
 		Route: "route",
@@ -529,6 +533,7 @@ func TestAgentResponseMID(t *testing.T) {
 			if table.mid != 0 {
 				mockEncoder.EXPECT().Encode(gomock.Any(), gomock.Any()).Return([]byte("ok!"), nil)
 				mockMetricsReporter.EXPECT().ReportGauge(metrics.ChannelCapacity, gomock.Any(), float64(10))
+				mockMetricsReporter.EXPECT().ReportHistogram(metrics.ChannelCapacityHistogram, gomock.Any(), float64(10))
 			}
 			if table.mid != 0 {
 				if table.err != nil {
@@ -582,6 +587,7 @@ func TestAgentResponseMIDFullChannel(t *testing.T) {
 	ag := newAgent(mockConn, mockDecoder, mockEncoder, mockSerializer, hbTime, writeTimeout, 0, dieChan, messageEncoder, mockMetricsReporters, sessionPool).(*agentImpl)
 	assert.NotNil(t, ag)
 	mockMetricsReporters[0].(*metricsmocks.MockReporter).EXPECT().ReportGauge(metrics.ChannelCapacity, gomock.Any(), float64(0))
+	mockMetricsReporters[0].(*metricsmocks.MockReporter).EXPECT().ReportHistogram(metrics.ChannelCapacityHistogram, gomock.Any(), float64(0))
 	go func() {
 		err := ag.ResponseMID(nil, 1, []byte("data"))
 		assert.NoError(t, err)
@@ -1205,6 +1211,7 @@ func TestNatsRPCServerReportMetrics(t *testing.T) {
 	ag.chSend <- pendingWrite{}
 
 	mockMetricsReporter.EXPECT().ReportGauge(metrics.ChannelCapacity, gomock.Any(), float64(-1)) // because buffersize is 0 and chan sz is 1
+	mockMetricsReporter.EXPECT().ReportHistogram(metrics.ChannelCapacityHistogram, gomock.Any(), float64(-1))
 	ag.reportChannelSize()
 }
 

--- a/cluster/nats_rpc_server.go
+++ b/cluster/nats_rpc_server.go
@@ -412,7 +412,9 @@ func (ns *NatsRPCServer) reportMetrics() {
 			if err := mr.ReportGauge(metrics.ChannelCapacity, map[string]string{"channel": "rpc_server_subchan"}, float64(subChanCapacity)); err != nil {
 				logger.Log.Warnf("failed to report subChan queue capacity: %s", err.Error())
 			}
-
+			if err := mr.ReportHistogram(metrics.ChannelCapacityHistogram, map[string]string{"channel": "rpc_server_subchan"}, float64(subChanCapacity)); err != nil {
+				logger.Log.Warnf("failed to report subChan queue capacity histogram: %s", err.Error())
+			}
 			// bindingschan
 			bindingsChanCapacity := ns.messagesBufferSize - len(ns.bindingsChan)
 			if bindingsChanCapacity == 0 {
@@ -420,6 +422,9 @@ func (ns *NatsRPCServer) reportMetrics() {
 			}
 			if err := mr.ReportGauge(metrics.ChannelCapacity, map[string]string{"channel": "rpc_server_bindingschan"}, float64(bindingsChanCapacity)); err != nil {
 				logger.Log.Warnf("failed to report bindingsChan capacity: %s", err.Error())
+			}
+			if err := mr.ReportHistogram(metrics.ChannelCapacityHistogram, map[string]string{"channel": "rpc_server_bindingschan"}, float64(bindingsChanCapacity)); err != nil {
+				logger.Log.Warnf("failed to report bindingsChan capacity histogram: %s", err.Error())
 			}
 
 			// userpushch
@@ -429,6 +434,9 @@ func (ns *NatsRPCServer) reportMetrics() {
 			}
 			if err := mr.ReportGauge(metrics.ChannelCapacity, map[string]string{"channel": "rpc_server_userpushchan"}, float64(userPushChanCapacity)); err != nil {
 				logger.Log.Warnf("failed to report userPushCh capacity: %s", err.Error())
+			}
+			if err := mr.ReportHistogram(metrics.ChannelCapacityHistogram, map[string]string{"channel": "rpc_server_userpushchan"}, float64(userPushChanCapacity)); err != nil {
+				logger.Log.Warnf("failed to report userPushCh capacity histogram: %s", err.Error())
 			}
 		}
 	}

--- a/cluster/nats_rpc_server_test.go
+++ b/cluster/nats_rpc_server_test.go
@@ -340,6 +340,7 @@ func TestNatsRPCServerHandleMessages(t *testing.T) {
 
 			mockMetricsReporter.EXPECT().ReportGauge(metrics.DroppedMessages, gomock.Any(), float64(0))
 			mockMetricsReporter.EXPECT().ReportGauge(metrics.ChannelCapacity, gomock.Any(), gomock.Any()).Times(3)
+			mockMetricsReporter.EXPECT().ReportHistogram(metrics.ChannelCapacityHistogram, gomock.Any(), gomock.Any()).Times(3)
 
 			conn.Publish(table.topic, b)
 			r := helpers.ShouldEventuallyReceive(t, rpcServer.unhandledReqCh).(*protos.Request)
@@ -542,5 +543,6 @@ func TestNatsRPCServerReportMetrics(t *testing.T) {
 
 	mockMetricsReporter.EXPECT().ReportGauge(metrics.DroppedMessages, gomock.Any(), float64(rpcServer.dropped))
 	mockMetricsReporter.EXPECT().ReportGauge(metrics.ChannelCapacity, gomock.Any(), float64(99)).Times(3)
+	mockMetricsReporter.EXPECT().ReportHistogram(metrics.ChannelCapacityHistogram, gomock.Any(), float64(99)).Times(3)
 	rpcServer.reportMetrics()
 }

--- a/metrics/prometheus_reporter.go
+++ b/metrics/prometheus_reporter.go
@@ -209,6 +209,7 @@ func (p *PrometheusReporter) registerMetrics(
 			ConstLabels: constLabels,
 		},
 		append([]string{"channel"}, additionalLabelsKeys...),
+	)
 
 	p.gaugeReportersMap[DroppedMessages] = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{


### PR DESCRIPTION
* fix missing parenthesis on tests
* add expected calls to histogram alongside gauge
* add histogram calls to nats rpc flows that also reports the channel capacity metrics for its own channels