### PR TITLE
Fix sessionByUID leak when there's a race condition between session closing and uid binding

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -223,6 +223,7 @@ func TestUniqueSession_ShouldSucceedIfKickFails(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Force break the connection so that the kick fails
+	// This will also force a race condition between binding and session closing
 	c1.Disconnect()
 
 	err = c2.ConnectTo(fmt.Sprintf("localhost:%d", port1))

--- a/session/session.go
+++ b/session/session.go
@@ -428,6 +428,12 @@ func (s *sessionImpl) Bind(ctx context.Context, uid string) error {
 		return constants.ErrSessionAlreadyBound
 	}
 
+	if s.IsFrontend {
+		if _, ok := s.pool.sessionsByID.Load(s.ID()); !ok {
+			return constants.ErrSessionNotFound
+		}
+	}
+
 	s.uid = uid
 	for _, cb := range s.pool.sessionBindCallbacks {
 		err := cb(ctx, s)

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -653,7 +653,7 @@ func TestSessionBindOnClosedSession(t *testing.T) {
 	uid := "test-uid"
 	err := ss.Bind(context.Background(), uid)
 
-	assert.ErrorIs(t, err, constants.ErrCloseClosedSession)
+	assert.ErrorIs(t, err, constants.ErrSessionNotFound)
 	assert.Equal(t, int64(0), sessionPool.GetSessionCount())
 	assert.Nil(t, sessionPool.GetSessionByUID(uid))
 }


### PR DESCRIPTION
It might happen that the server processes a `uid` binding at the same time, or right after the session is closed. In such situations, the session is re-added to the `sessionByUID`, making it leak and be wrongly accessible when calling `GetSessionByUID`.

Once this happens, it ends up making the issue reported by #452 happen consistently for users when trying to connect to the same instance that had the session leaked. For the scenario of multiple frontend instances, the problem is mitigated, as the chances of a client ending up consistently in the same instance is small.

This PR addresses the issue by validating whether the session is present in `sessionByID` before binding the `uid`. The validation is done before the `sessionBindCallbacks` are called so to avoid triggering false positive invocations.