### PR TITLE
fix(agent): wrap kick error instead of metadata

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -297,6 +297,9 @@ func TestKickNetworkErrors(t *testing.T) {
 			var pitayaErr *e.Error
 			assert.True(t, errors.As(err, &pitayaErr))
 			assert.Equal(t, row.expectedError, pitayaErr.Code)
+
+			// Verify that the underlying error message is preserved in the error message
+			// Since Pitaya errors don't support unwrapping, we check if the message contains the original error
 			assert.Contains(t, err.Error(), row.writeError.Error())
 		})
 	}


### PR DESCRIPTION
Errors from generic functions used across multiple flows, like socket write, lacks context on which flow triggered the error. Previously, this context was added as a hardcoded reason key in error struct, which is not ideal. Thus, changing the error to wrap the underlying net/socket error with caller function