### PR TITLE
fix: It's best to call SetDeadline before write.

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -414,6 +414,9 @@ func (a *agentImpl) Kick(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	if err = a.conn.SetDeadline(time.Now().Add(a.writeTimeout)); err != nil {
+		return err
+	}
 	_, err = a.conn.Write(p)
 	return err
 }


### PR DESCRIPTION
When `session.Kick` is called, it directly calls the `Agent.Kick` method. However, `Agent.Kick` does not set a `writeTimeout` when writing the Kick Packet using the underlying `conn`. This can cause the method to return an I/O timeout in some scenarios. For example, the code here also sets a timeout parameter, which will affect the write behavior during Kick.

```
func (a *agentImpl) writeToConnection(ctx context.Context, data []byte) error {
	span := createConnectionSpan(ctx, a.conn, "conn write")

	a.conn.SetWriteDeadline(time.Now().Add(a.writeTimeout))
	_, writeErr := a.conn.Write(data)

	if span != nil {
		defer span.End()

		if writeErr != nil {
			span.RecordError(writeErr)
			span.SetStatus(codes.Error, writeErr.Error())
		}
	}

	return writeErr
}
```
https://github.com/topfreegames/pitaya/blob/main/pkg/agent/agent.go#L566
