### PR TITLE
[v2] Add IsReady method to App interface and implement connection checks

### DIFF
--- a/app.go
+++ b/app.go
@@ -27,7 +27,6 @@ import (
 	"reflect"
 	"strings"
 	"syscall"
-
 	"time"
 
 	"github.com/golang/protobuf/proto"
@@ -128,6 +127,7 @@ type Pitaya interface {
 	GetModule(name string) (interfaces.Module, error)
 
 	GetNumberOfConnectedClients() int64
+	IsReady(ctx context.Context) bool
 }
 
 // App is the base app struct
@@ -566,4 +566,42 @@ func (app *App) RegisterRPCJob(rpcJob worker.RPCJob) error {
 // GetNumberOfConnectedClients returns the number of connected clients
 func (app *App) GetNumberOfConnectedClients() int64 {
 	return app.sessionPool.GetSessionCount()
+}
+
+// IsReady checks if pitaya is ready and able to serve requests
+func (app *App) IsReady(ctx context.Context) bool {
+	if !app.IsRunning() {
+		return false
+	}
+
+	// Check NATS RPC Client connection
+	if app.rpcClient != nil {
+		if natsClient, ok := app.rpcClient.(*cluster.NatsRPCClient); ok {
+			if !natsClient.IsConnected() {
+				logger.Log.Info("pitaya is not ready")
+				return false
+			}
+		}
+	}
+
+	// Check NATS RPC Server connection
+	if app.rpcServer != nil {
+		if natsServer, ok := app.rpcServer.(*cluster.NatsRPCServer); ok {
+			if !natsServer.IsConnected() {
+				logger.Log.Info("pitaya is not ready")
+				return false
+			}
+		}
+	}
+
+	// Check ETCD connection
+	if app.serviceDiscovery != nil {
+		if !app.serviceDiscovery.IsConnected(ctx) {
+			logger.Log.Info("pitaya is not ready")
+			return false
+		}
+	}
+
+	logger.Log.Info("pitaya is ready")
+	return true
 }

--- a/cluster/etcd_service_discovery.go
+++ b/cluster/etcd_service_discovery.go
@@ -550,7 +550,7 @@ func (sd *etcdServiceDiscovery) SyncServers(firstSync bool) error {
 	}
 
 	// delete invalid servers (local ones that are not in etcd)
-	var allIds = make([]string, 0)
+	allIds := make([]string, 0)
 
 	// Spawn worker goroutines that will work in parallel
 	parallelGetter := newParallelGetter(sd.cli, sd.syncServersParallelism)
@@ -716,7 +716,6 @@ func (sd *etcdServiceDiscovery) watchEtcdChanges() {
 			case <-sd.stopChan:
 				return
 			}
-
 		}
 	}(w)
 }
@@ -728,4 +727,16 @@ func (sd *etcdServiceDiscovery) isServerTypeBlacklisted(svType string) bool {
 		}
 	}
 	return false
+}
+
+func (sd *etcdServiceDiscovery) IsConnected(ctx context.Context) bool {
+	if sd.cli == nil {
+		return false
+	}
+
+	checkCtx, cancel := context.WithTimeout(ctx, sd.revokeTimeout)
+	defer cancel()
+
+	_, err := sd.cli.Get(checkCtx, "health-check", clientv3.WithLimit(1))
+	return err == nil
 }

--- a/cluster/mocks/service_discovery.go
+++ b/cluster/mocks/service_discovery.go
@@ -5,6 +5,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -154,4 +155,18 @@ func (m *MockServiceDiscovery) SyncServers(firstSync bool) error {
 func (mr *MockServiceDiscoveryMockRecorder) SyncServers(firstSync interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncServers", reflect.TypeOf((*MockServiceDiscovery)(nil).SyncServers), firstSync)
+}
+
+// IsConnected mocks base method.
+func (m *MockServiceDiscovery) IsConnected(arg0 context.Context) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsConnected", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsConnected indicates an expected call of IsConnected.
+func (mr *MockServiceDiscoveryMockRecorder) IsConnected(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsConnected", reflect.TypeOf((*MockServiceDiscovery)(nil).IsConnected), arg0)
 }

--- a/cluster/nats_rpc_client.go
+++ b/cluster/nats_rpc_client.go
@@ -260,7 +260,6 @@ func (ns *NatsRPCClient) Init() error {
 
 // initConnection initializes or replaces the NATS connection
 func (ns *NatsRPCClient) initConnection(isReplacement bool) error {
-
 	if !isReplacement {
 		ns.running = true
 		logger.Log.Debugf("connecting to nats (client) with timeout of %s", ns.connectionTimeout)
@@ -309,4 +308,8 @@ func (ns *NatsRPCClient) stop() {
 
 func (ns *NatsRPCClient) getSubscribeChannel() string {
 	return fmt.Sprintf("pitaya/servers/%s/%s", ns.server.Type, ns.server.ID)
+}
+
+func (ns *NatsRPCClient) IsConnected() bool {
+	return ns.conn != nil && ns.conn.IsConnected()
 }

--- a/cluster/nats_rpc_server.go
+++ b/cluster/nats_rpc_server.go
@@ -350,7 +350,6 @@ func (ns *NatsRPCServer) Init() error {
 
 // initConnection initializes or replaces the NATS connection
 func (ns *NatsRPCServer) initConnection(isReplacement bool) error {
-
 	if !isReplacement {
 		// TODO should we have concurrency here? it feels like we should
 		go ns.handleMessages()
@@ -481,4 +480,8 @@ func (ns *NatsRPCServer) reportMetrics() {
 			}
 		}
 	}
+}
+
+func (ns *NatsRPCServer) IsConnected() bool {
+	return ns.conn != nil && ns.conn.IsConnected()
 }

--- a/cluster/service_discovery.go
+++ b/cluster/service_discovery.go
@@ -20,7 +20,11 @@
 
 package cluster
 
-import "github.com/topfreegames/pitaya/v2/interfaces"
+import (
+	"context"
+
+	"github.com/topfreegames/pitaya/v2/interfaces"
+)
 
 // ServiceDiscovery is the interface for a service discovery client
 type ServiceDiscovery interface {
@@ -29,5 +33,6 @@ type ServiceDiscovery interface {
 	GetServers() []*Server
 	SyncServers(firstSync bool) error
 	AddListener(listener SDListener)
+	IsConnected(ctx context.Context) bool
 	interfaces.Module
 }

--- a/mocks/app.go
+++ b/mocks/app.go
@@ -638,3 +638,17 @@ func (mr *MockPitayaMockRecorder) StartWorker() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartWorker", reflect.TypeOf((*MockPitaya)(nil).StartWorker))
 }
+
+// IsReady mocks base method.
+func (m *MockPitaya) IsReady(arg0 context.Context) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsReady", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsReady indicates an expected call of IsReady.
+func (mr *MockPitayaMockRecorder) IsReady(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsReady", reflect.TypeOf((*MockPitaya)(nil).IsReady), arg0)
+}

--- a/static.go
+++ b/static.go
@@ -230,3 +230,7 @@ func GetModule(name string) (interfaces.Module, error) {
 func GetNumberOfConnectedClients() int64 {
 	return DefaultApp.GetNumberOfConnectedClients()
 }
+
+func IsReady(ctx context.Context) bool {
+	return DefaultApp.IsReady(ctx)
+}


### PR DESCRIPTION
### Description

This PR introduces a new `IsReady()` method to the Pitaya interface that provides one step to make a health check mechanism to determine if the metagame/connector is ready to serve requests.

### Motivation

- Requests being routed to instances that haven't fully connected to required services (NATS, ETCD)
- Failed requests during service startup
- Difficulty implementing proper readiness probes in Kubernetes environments

### Core Functionality

The `IsReady()` method validates:
- **Application Running State**: Checks if `app.IsRunning()` returns true
- **NATS RPC Client Connection**: Verifies NATS client is connected (if configured)
- **NATS RPC Server Connection**: Verifies NATS server is connected (if configured)
-**ETCD Service Discovery**: Validates ETCD connection health (if configured)


### Usage Example

### HTTP Server to Health Check example

```go
//main.go
func initializeServer(flags *cluster.StartCommandFlags) {
	var (
		viper       = viper.GetViper()
		logger      = logging.NewLogger(gameID, flags.ServerType, logFormat, verbosity)
		fieldLogger = logging.NewFieldLogger(gameID, flags.ServerType, logFormat, verbosity)
	)

	fixViperEnvVars(viper)

	err := configureJaeger(viper)
	if err != nil {
		logger.WithError(err).Error("Could not configure Jaeger")
	}

	if flags.ServerType == servers.CS {
		servers.StartCSServer(viper, logger, verbosity)
		return
	}

	var app pitaya.Pitaya

	switch flags.ServerType {
	case servers.Connector:
		app = servers.NewConnectorServer(viper, logger, flags)
	case servers.Metagame:
		app = servers.NewMetagameServer(viper, logger, fieldLogger, verbosity)
	case servers.WorkerClanWars:
		app = servers.NewWorkerClanWars(viper, logger)
	case servers.WorkerSplitServer:
		app = servers.NewWorkerSplitServer(viper, logger)
	default:
		logger.Fatalf("Unknown server type: %s", flags.ServerType)
	}

	pitaya.SetLogger(logger)
	
	// HERE
	go startHealthServer(app, 8080, logger)
	
	app.Start()  // Blocking Operation
}
```

```go
//health_server.go
func startHealthServer(app pitaya.Pitaya, port int, logger interface{}) {
	http.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
		if app.IsRunning() {
			w.WriteHeader(http.StatusOK)
			fmt.Fprint(w, "alive")
		} else {
			w.WriteHeader(http.StatusServiceUnavailable)
			fmt.Fprint(w, "dead")
		}
	})

	http.HandleFunc("/readyz", func(w http.ResponseWriter, r *http.Request) {
		ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
		defer cancel()
                 //HERE
		if app.IsReady(ctx) {
			w.WriteHeader(http.StatusOK)
			fmt.Fprint(w, "ready")
		} else {
			w.WriteHeader(http.StatusServiceUnavailable)
			fmt.Fprint(w, "not ready")
		}
	})

	http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
		ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
		defer cancel()

		ready := app.IsReady(ctx)
		status := map[string]interface{}{
			"ready":             ready,
			"running":           app.IsRunning(),
			"connected_clients": app.GetNumberOfConnectedClients(),
		}

		w.Header().Set("Content-Type", "application/json")
		if ready {
			w.WriteHeader(http.StatusOK)
		} else {
			w.WriteHeader(http.StatusServiceUnavailable)
		}
		json.NewEncoder(w).Encode(status)
	})

	if log, ok := logger.(interface{ Infof(string, ...interface{}) }); ok {
		log.Infof("Health check server listening on :%d", port)
	}

	if err := http.ListenAndServe(fmt.Sprintf(":%d", port), nil); err != nil {
		if log, ok := logger.(interface{ Errorf(string, ...interface{}) }); ok {
			log.Errorf("Health server error: %v", err)
		}
	}
}
```
