### PR TITLE
fix:Connector fails to register with Service Discovery when using WSS (WebSocket Secure)

### DIFF
--- a/acceptor/ws_acceptor.go
+++ b/acceptor/ws_acceptor.go
@@ -156,6 +156,7 @@ func (w *WSAcceptor) ListenAndServeTLS(cert, key string) {
 		logger.Log.Fatalf("Failed to listen: %s", err.Error())
 	}
 	w.listener = listener
+	w.running = true
 	w.serve(&upgrader)
 }
 


### PR DESCRIPTION
Connector fails to register with Service Discovery when using WSS (WebSocket Secure) #488

fix:https://github.com/topfreegames/pitaya/issues/488

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small state-management fix confined to the WSS/TLS listen path; low risk aside from slightly changing lifecycle signaling for TLS deployments.
> 
> **Overview**
> Fixes a lifecycle/state bug in `WSAcceptor` when running over WSS/TLS by setting `w.running = true` after the TLS listener is created (matching the non-TLS path).
> 
> This ensures components that rely on the acceptor "running" state (e.g., registration/health checks) see the correct status when using `ListenAndServeTLS`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3eccbfd4cb8eca17a0e200ac0eabdd5352d7f657. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->