### PR TITLE
fix(agent): capture error code before packetEncodeMessage mutates payload

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,7 @@ init-submodules:
 	@git submodule init
 
 setup-ci:
-	@go install github.com/mattn/goveralls@latest
-	@go install github.com/wadey/gocovmerge@latest
+	@go install github.com/mattn/goveralls@v0.0.12
 
 setup-protobuf-macos:
 	@brew install protobuf
@@ -165,16 +164,12 @@ test-coverage: unit-test-coverage
 test-coverage-html: test-coverage
 	@go tool cover -html=coverprofile.out
 
-merge-profiles:
-	@rm -f coverage-all.out
-	@gocovmerge *.out > coverage-all.out
-
-test-coverage-func coverage-func: test-coverage merge-profiles
+test-coverage-func coverage-func: test-coverage
 	@echo
 	@echo "\033[1;34m=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-\033[0m"
 	@echo "\033[1;34mFunctions NOT COVERED by Tests\033[0m"
 	@echo "\033[1;34m=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-\033[0m"
-	@go tool cover -func=coverage-all.out | egrep -v "100.0[%]"
+	@go tool cover -func=coverprofile.out | egrep -v "100.0[%]"
 
 mocks: agent-mock session-mock networkentity-mock pitaya-mock serializer-mock metrics-mock acceptor-mock
 

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -286,6 +286,21 @@ func (a *agentImpl) send(pendingMsg pendingMessage) (err error) {
 		return err
 	}
 
+	pWrite := pendingWrite{
+		ctx: pendingMsg.ctx,
+	}
+
+	// Capture the error code from the payload BEFORE packetEncodeMessage
+	// runs, because MessagesEncoder.Encode mutates m.Data in place when
+	// compression produces smaller output. If we read m.Data after encoding,
+	// the payload may be deflated bytes and GetErrorFromPayload's silent
+	// Unmarshal failure causes the metric code tag to fall back to the
+	// default ErrUnknownCode (PIT-000), masking the real status code for
+	// any error whose JSON payload is large enough to compress.
+	if pendingMsg.err {
+		pWrite.err = util.GetErrorFromPayload(a.serializer, m.Data)
+	}
+
 	// packet encode
 	p, err := a.packetEncodeMessage(m)
 	if err != nil {
@@ -295,15 +310,7 @@ func (a *agentImpl) send(pendingMsg pendingMessage) (err error) {
 		)
 		return err
 	}
-
-	pWrite := pendingWrite{
-		ctx:  pendingMsg.ctx,
-		data: p,
-	}
-
-	if pendingMsg.err {
-		pWrite.err = util.GetErrorFromPayload(a.serializer, m.Data)
-	}
+	pWrite.data = p
 
 	// chSend is never closed so we need this to don't block if agent is already closed
 	select {

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -51,8 +51,11 @@ import (
 	"github.com/topfreegames/pitaya/v3/pkg/mocks"
 	"github.com/topfreegames/pitaya/v3/pkg/protos"
 	"github.com/topfreegames/pitaya/v3/pkg/serialize"
+	serializejson "github.com/topfreegames/pitaya/v3/pkg/serialize/json"
 	serializemocks "github.com/topfreegames/pitaya/v3/pkg/serialize/mocks"
 	"github.com/topfreegames/pitaya/v3/pkg/session"
+	"github.com/topfreegames/pitaya/v3/pkg/util"
+	"github.com/topfreegames/pitaya/v3/pkg/util/compression"
 )
 
 type mockAddr struct{}
@@ -1348,4 +1351,88 @@ func TestAgentWriteChSendWriteTimeout(t *testing.T) {
 	ag.chSend <- pendingWrite{ctx: ctx, data: expectedFirstPacket, err: nil}
 	ag.chSend <- pendingWrite{ctx: ctx, data: expectedSecondPacket, err: nil}
 	wg.Wait()
+}
+
+// TestAgentResponseMIDPreservesErrorCodeWithCompression regresses a bug
+// where the code tag on the response_time metric fell back to
+// errors.ErrUnknownCode ("PIT-000") instead of carrying the real status
+// code returned by the handler.
+//
+// Root cause: MessagesEncoder.Encode mutates message.Data in place to
+// deflated bytes when compression produces smaller output. The send()
+// function used to read the error code from m.Data AFTER calling
+// packetEncodeMessage, so GetErrorFromPayload would try to JSON-unmarshal
+// deflated bytes, silently fail, and return a default-coded Error. The
+// payload on the wire still carried the right code (clients were not
+// affected), but monitors filtering by the `code` tag broke.
+//
+// This test exercises the end-to-end flow with compression enabled and an
+// error payload whose metadata is large enough to compress smaller than
+// the source. It asserts that pendingWrite.err carries the original code.
+func TestAgentResponseMIDPreservesErrorCodeWithCompression(t *testing.T) {
+	originalCode := "PIT-COMPRESSION-TEST"
+	originalMsg := "an error whose payload is large enough to compress"
+	originalMetadata := map[string]string{
+		"contextual_field_a": "contextual value a worth some bytes",
+		"contextual_field_b": "contextual value b worth some bytes",
+		"contextual_field_c": "contextual value c worth some bytes",
+	}
+
+	jsonSerializer := serializejson.NewSerializer()
+	originalErr := &e.Error{
+		Code:     originalCode,
+		Message:  originalMsg,
+		Metadata: originalMetadata,
+	}
+	payload, err := util.GetErrorPayload(jsonSerializer, originalErr)
+	require.NoError(t, err)
+
+	// Sanity check: the test premise requires deflate to produce fewer
+	// bytes than the source so that MessagesEncoder.Encode takes the
+	// mutating branch. If this fails, enlarge the metadata above.
+	deflated, err := compression.DeflateData(payload)
+	require.NoError(t, err)
+	require.Less(t, len(deflated), len(payload),
+		"test payload must compress smaller than source to exercise the bug (payload=%d, deflated=%d)",
+		len(payload), len(deflated))
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockEncoder := codecmocks.NewMockPacketEncoder(ctrl)
+	heartbeatAndHandshakeMocks(mockEncoder)
+	mockDecoder := codecmocks.NewMockPacketDecoder(ctrl)
+	mockConn := mocks.NewMockPlayerConn(ctrl)
+	dieChan := make(chan bool)
+	messageEncoder := message.NewMessagesEncoder(true) // compression ON
+	sessionPool := session.NewSessionPool()
+
+	ag := newAgent(
+		mockConn, mockDecoder, mockEncoder, jsonSerializer,
+		time.Second, time.Second, 10, dieChan,
+		messageEncoder, nil, sessionPool,
+	).(*agentImpl)
+	require.NotNil(t, ag)
+
+	mockEncoder.EXPECT().
+		Encode(packet.Type(packet.Data), gomock.Any()).
+		Return([]byte("encoded-packet"), nil)
+
+	ctx := getCtxWithRequestKeys()
+	require.NoError(t, ag.ResponseMID(ctx, uint(42), payload, true))
+
+	recv := helpers.ShouldEventuallyReceive(t, ag.chSend).(pendingWrite)
+	require.NotNil(t, recv.err,
+		"pendingWrite.err must be set when ResponseMID is called with isError=true")
+
+	recovered, ok := recv.err.(*e.Error)
+	require.Truef(t, ok, "pendingWrite.err must be *errors.Error, got %T", recv.err)
+
+	assert.Equalf(t, originalCode, recovered.Code,
+		"pendingWrite.err.Code was %q, expected %q — compression likely mutated m.Data "+
+			"before GetErrorFromPayload read it; the metric `code` tag will be wrong for "+
+			"any error whose payload compresses smaller than the source",
+		recovered.Code, originalCode)
+	assert.Equal(t, originalMsg, recovered.Message)
+	assert.Equal(t, originalMetadata, recovered.Metadata)
 }


### PR DESCRIPTION
## Problem

`MessagesEncoder.Encode` mutates `message.Data` in place when compression
produces smaller output than the source. The `send()` function in
`agent/agent.go` reads the error code from `m.Data` **after** calling
`packetEncodeMessage`, so when compression triggers, `util.GetErrorFromPayload`
receives deflated bytes. The JSON unmarshal inside that function silently
fails (the error is discarded with `_ = serializer.Unmarshal(...)`), and
the returned `Error` falls back to `ErrUnknownCode` (`"PIT-000"`).

## Effect

The wire payload still carries the correct code — **clients are not affected**.
But `pendingWrite.err`, and therefore the `code` tag on the `response_time`
metric emitted by `ReportTimingFromCtx`, loses the code for any error whose
JSON payload compresses smaller than the source (typically any error that
carries metadata via `pitaya.Error(err, code, metadata)`).

Monitors that filter by `code` (e.g. excluding expected application errors
from an error rate alert) break silently because the tag they expect is
replaced with `PIT-000`. Error kinds become indistinguishable in metrics.

The bug is payload-size dependent: small errors (no metadata, deflate
overhead > savings) are unaffected.

## Fix

Capture the error via `util.GetErrorFromPayload` **before**
`packetEncodeMessage` runs, while `m.Data` still holds the original
serialized bytes. Only the metric tag is affected; the wire format, packet
layout, and payload sent to clients are unchanged.

## Test

Adds `TestAgentResponseMIDPreservesErrorCodeWithCompression`. Builds an
error payload large enough to trigger compression, calls `ResponseMID`
with `isError=true` through an agent configured with a real JSON serializer
and a `MessagesEncoder(true)`, asserts `pendingWrite.err` carries the
original code.

Without this change the test fails with:
pendingWrite.err.Code was "PIT-000", expected "PIT-COMPRESSION-TEST"



## Scope

- Single-function reorder in `send()`.
- No API change.
- No wire format change.
- No behavioral change for non-error responses or for errors whose payload
  does not compress smaller than the source.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small reorder in `agent.send` only affects how the error used for metrics tagging is captured, plus a focused regression test and minor CI/coverage Makefile tweaks.
> 
> **Overview**
> Fixes a metrics-tagging bug where compressed error responses could cause `pendingWrite.err` (and the `response_time` metric `code` tag) to fall back to `PIT-000` by capturing the error from the original payload *before* `packetEncodeMessage` mutates `message.Data` for compression.
> 
> Adds `TestAgentResponseMIDPreservesErrorCodeWithCompression` to reproduce the compression/mutation case end-to-end and assert the original error code is preserved.
> 
> Updates the Makefile to pin `goveralls` and drop `gocovmerge`/profile merging, using `coverprofile.out` directly for the uncovered-functions report.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f0ca1a80df09228a1d584653aa065b3b143c5ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->