### PR TITLE
Add IsNotWsError method to WSConn

### DIFF
--- a/pkg/acceptor/ws_acceptor.go
+++ b/pkg/acceptor/ws_acceptor.go
@@ -192,10 +192,18 @@ func NewWSConn(conn *websocket.Conn) (*WSConn, error) {
 	return c, nil
 }
 
+// IsNotWsError
+func (c *WSConn) IsNotWsError(err error) bool {
+	// Ignore normal closure errors
+	// 1000: Normal closure
+	// 1001: Going away
+	return !websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway)
+}
+
 // GetNextMessage reads the next message available in the stream
 func (c *WSConn) GetNextMessage() (b []byte, err error) {
 	_, msgBytes, err := c.conn.ReadMessage()
-	if err != nil {
+	if err != nil && c.IsNotWsError(err) {
 		return nil, err
 	}
 	if len(msgBytes) < codec.HeadLength {


### PR DESCRIPTION
Ignore normal closure errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes error handling in `WSConn.GetNextMessage` to suppress expected close codes; main risk is masking unexpected shutdowns if callers relied on those errors.
> 
> **Overview**
> **WebSocket reads now ignore normal close events.** A new `WSConn.IsNotWsError` helper treats close codes `1000` (normal closure) and `1001` (going away) as non-errors.
> 
> `WSConn.GetNextMessage` now returns an error from `ReadMessage` only when it is *not* one of those normal closure conditions, reducing noisy errors on routine disconnects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae8e7aa3a648f0846da06c3b98f745ea290d1823. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->