### PR TITLE
Fix `supportted` -> `supported` typo in features doc

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -140,7 +140,7 @@ ctx := pcontext.AddToPropagateCtx(context.Background(), constants.RequestTimeout
 
 then transfer the ctx to RPC() or RPCTo() function as the context parameter
 
-**Note**: this feature is only supportted while using nats currently.
+**Note**: this feature is only supported while using nats currently.
 
 ## Server operation mode
 


### PR DESCRIPTION
Line 143 of `docs/features.md` has `supportted` (extra t) in nats note.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change correcting a misspelling; no runtime behavior is affected.
> 
> **Overview**
> Fixes a misspelling in `docs/features.md` by changing `supportted` to `supported` in the note about per-request RPC timeouts being supported only with NATS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0112b310bd20e8d924d5a27f22e2f1ce9a6a206. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->