### PR TITLE
feat(metrics): instrument handler/RPC channel buffers and worker pools

### DIFF
--- a/app.go
+++ b/app.go
@@ -286,6 +286,15 @@ func (app *App) periodicMetrics() {
 	period := app.config.Metrics.Period
 	go metrics.ReportSysMetrics(app.metricsReporters, period)
 
+	if app.handlerService != nil {
+		go func() {
+			for {
+				app.handlerService.ReportMetrics()
+				time.Sleep(period)
+			}
+		}()
+	}
+
 	if app.worker.Started() {
 		go worker.Report(app.metricsReporters, period)
 	}

--- a/cluster/nats_rpc_server.go
+++ b/cluster/nats_rpc_server.go
@@ -25,6 +25,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"sync/atomic"
 	"time"
 
 	"github.com/golang/protobuf/proto"
@@ -59,6 +60,7 @@ type NatsRPCServer struct {
 	userKickCh             chan *protos.KickMsg
 	sub                    *nats.Subscription
 	dropped                int
+	busyRemoteWorkers      int32 // atomic: number of processMessages workers currently in pitayaServer.Call
 	pitayaServer           protos.PitayaServer
 	metricsReporters       []metrics.Reporter
 	sessionPool            session.SessionPool
@@ -288,7 +290,9 @@ func (ns *NatsRPCServer) processMessages(threadID int) {
 
 			logger.Log.Errorf("error getting context from request: %s", err)
 		} else {
+			atomic.AddInt32(&ns.busyRemoteWorkers, 1)
 			ns.responses[threadID], err = ns.pitayaServer.Call(ctx, ns.requests[threadID])
+			atomic.AddInt32(&ns.busyRemoteWorkers, -1)
 			if err != nil {
 				logger.Log.Errorf("error processing route %s: %s", ns.requests[threadID].GetMsg().GetRoute(), err)
 			}
@@ -438,48 +442,24 @@ func (ns *NatsRPCServer) stop() {
 }
 
 func (ns *NatsRPCServer) reportMetrics() {
-	if ns.metricsReporters != nil {
-		for _, mr := range ns.metricsReporters {
-			if err := mr.ReportGauge(metrics.DroppedMessages, map[string]string{}, float64(ns.dropped)); err != nil {
-				logger.Log.Warnf("failed to report dropped message: %s", err.Error())
-			}
-
-			// subchan
-			subChanCapacity := ns.messagesBufferSize - len(ns.subChan)
-			if subChanCapacity == 0 {
-				logger.Log.Warn("subChan is at maximum capacity")
-			}
-			if err := mr.ReportGauge(metrics.ChannelCapacity, map[string]string{"channel": "rpc_server_subchan"}, float64(subChanCapacity)); err != nil {
-				logger.Log.Warnf("failed to report subChan queue capacity: %s", err.Error())
-			}
-			if err := mr.ReportHistogram(metrics.ChannelCapacityHistogram, map[string]string{"channel": "rpc_server_subchan"}, float64(subChanCapacity)); err != nil {
-				logger.Log.Warnf("failed to report subChan queue capacity histogram: %s", err.Error())
-			}
-			// bindingschan
-			bindingsChanCapacity := ns.messagesBufferSize - len(ns.bindingsChan)
-			if bindingsChanCapacity == 0 {
-				logger.Log.Warn("bindingsChan is at maximum capacity")
-			}
-			if err := mr.ReportGauge(metrics.ChannelCapacity, map[string]string{"channel": "rpc_server_bindingschan"}, float64(bindingsChanCapacity)); err != nil {
-				logger.Log.Warnf("failed to report bindingsChan capacity: %s", err.Error())
-			}
-			if err := mr.ReportHistogram(metrics.ChannelCapacityHistogram, map[string]string{"channel": "rpc_server_bindingschan"}, float64(bindingsChanCapacity)); err != nil {
-				logger.Log.Warnf("failed to report bindingsChan capacity histogram: %s", err.Error())
-			}
-
-			// userpushch
-			userPushChanCapacity := ns.pushBufferSize - len(ns.userPushCh)
-			if userPushChanCapacity == 0 {
-				logger.Log.Warn("userPushChan is at maximum capacity")
-			}
-			if err := mr.ReportGauge(metrics.ChannelCapacity, map[string]string{"channel": "rpc_server_userpushchan"}, float64(userPushChanCapacity)); err != nil {
-				logger.Log.Warnf("failed to report userPushCh capacity: %s", err.Error())
-			}
-			if err := mr.ReportHistogram(metrics.ChannelCapacityHistogram, map[string]string{"channel": "rpc_server_userpushchan"}, float64(userPushChanCapacity)); err != nil {
-				logger.Log.Warnf("failed to report userPushCh capacity histogram: %s", err.Error())
-			}
+	if len(ns.metricsReporters) == 0 {
+		return
+	}
+	for _, mr := range ns.metricsReporters {
+		if err := mr.ReportGauge(metrics.DroppedMessages, map[string]string{}, float64(ns.dropped)); err != nil {
+			logger.Log.Warnf("failed to report dropped message: %s", err.Error())
 		}
 	}
+
+	// incoming rpc messages, session bindings and outgoing user pushes/kicks all share
+	// the configured buffers; report the available capacity (free slots) of each
+	metrics.ReportChannelCapacity(ns.metricsReporters, "rpc_server_subchan", ns.messagesBufferSize-len(ns.subChan))
+	metrics.ReportChannelCapacity(ns.metricsReporters, "rpc_server_bindingschan", ns.messagesBufferSize-len(ns.bindingsChan))
+	metrics.ReportChannelCapacity(ns.metricsReporters, "rpc_server_userpushchan", ns.pushBufferSize-len(ns.userPushCh))
+	metrics.ReportChannelCapacity(ns.metricsReporters, "rpc_server_userkickchan", ns.messagesBufferSize-len(ns.userKickCh))
+
+	// remote request worker pool utilization (sized by cluster.rpc.server.nats.services)
+	metrics.ReportWorkerPoolUsage(ns.metricsReporters, "rpc_server_remote", int(atomic.LoadInt32(&ns.busyRemoteWorkers)), ns.service)
 }
 
 func (ns *NatsRPCServer) IsConnected() bool {

--- a/cluster/nats_rpc_server_test.go
+++ b/cluster/nats_rpc_server_test.go
@@ -339,8 +339,10 @@ func TestNatsRPCServerHandleMessages(t *testing.T) {
 			assert.NoError(t, err)
 
 			mockMetricsReporter.EXPECT().ReportGauge(metrics.DroppedMessages, gomock.Any(), float64(0))
-			mockMetricsReporter.EXPECT().ReportGauge(metrics.ChannelCapacity, gomock.Any(), gomock.Any()).Times(3)
-			mockMetricsReporter.EXPECT().ReportHistogram(metrics.ChannelCapacityHistogram, gomock.Any(), gomock.Any()).Times(3)
+			mockMetricsReporter.EXPECT().ReportGauge(metrics.ChannelCapacity, gomock.Any(), gomock.Any()).Times(4)
+			mockMetricsReporter.EXPECT().ReportHistogram(metrics.ChannelCapacityHistogram, gomock.Any(), gomock.Any()).Times(4)
+			mockMetricsReporter.EXPECT().ReportGauge(metrics.WorkerPoolBusyWorkers, gomock.Any(), gomock.Any())
+			mockMetricsReporter.EXPECT().ReportGauge(metrics.WorkerPoolTotalWorkers, gomock.Any(), gomock.Any())
 
 			conn.Publish(table.topic, b)
 			r := helpers.ShouldEventuallyReceive(t, rpcServer.unhandledReqCh).(*protos.Request)
@@ -542,7 +544,14 @@ func TestNatsRPCServerReportMetrics(t *testing.T) {
 	rpcServer.userPushCh <- &protos.Push{}
 
 	mockMetricsReporter.EXPECT().ReportGauge(metrics.DroppedMessages, gomock.Any(), float64(rpcServer.dropped))
+	// subChan, bindingsChan and userPushCh each hold one message -> 99 free slots
 	mockMetricsReporter.EXPECT().ReportGauge(metrics.ChannelCapacity, gomock.Any(), float64(99)).Times(3)
 	mockMetricsReporter.EXPECT().ReportHistogram(metrics.ChannelCapacityHistogram, gomock.Any(), float64(99)).Times(3)
+	// userKickCh is empty -> full capacity available
+	mockMetricsReporter.EXPECT().ReportGauge(metrics.ChannelCapacity, gomock.Any(), float64(100))
+	mockMetricsReporter.EXPECT().ReportHistogram(metrics.ChannelCapacityHistogram, gomock.Any(), float64(100))
+	// remote worker pool: none busy, sized by cluster.rpc.server.nats.services
+	mockMetricsReporter.EXPECT().ReportGauge(metrics.WorkerPoolBusyWorkers, gomock.Any(), float64(0))
+	mockMetricsReporter.EXPECT().ReportGauge(metrics.WorkerPoolTotalWorkers, gomock.Any(), float64(rpcServer.service))
 	rpcServer.reportMetrics()
 }

--- a/metrics/constants.go
+++ b/metrics/constants.go
@@ -31,4 +31,10 @@ var (
 	// ExceededRateLimiting reports the number of requests made in a connection
 	// after the rate limit was exceeded
 	ExceededRateLimiting = "exceeded_rate_limiting"
+	// WorkerPoolBusyWorkers reports the number of workers of a goroutine pool that
+	// are currently processing a message (labeled by pool)
+	WorkerPoolBusyWorkers = "busy_workers"
+	// WorkerPoolTotalWorkers reports the total number of workers of a goroutine pool
+	// (labeled by pool); together with WorkerPoolBusyWorkers it describes pool utilization
+	WorkerPoolTotalWorkers = "total_workers"
 )

--- a/metrics/prometheus_reporter.go
+++ b/metrics/prometheus_reporter.go
@@ -224,6 +224,28 @@ func (p *PrometheusReporter) registerMetrics(
 		additionalLabelsKeys,
 	)
 
+	p.gaugeReportersMap[WorkerPoolBusyWorkers] = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace:   "pitaya",
+			Subsystem:   "worker_pool",
+			Name:        WorkerPoolBusyWorkers,
+			Help:        "the number of workers of a goroutine pool currently processing a message",
+			ConstLabels: constLabels,
+		},
+		append([]string{"pool"}, additionalLabelsKeys...),
+	)
+
+	p.gaugeReportersMap[WorkerPoolTotalWorkers] = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace:   "pitaya",
+			Subsystem:   "worker_pool",
+			Name:        WorkerPoolTotalWorkers,
+			Help:        "the total number of workers of a goroutine pool",
+			ConstLabels: constLabels,
+		},
+		append([]string{"pool"}, additionalLabelsKeys...),
+	)
+
 	p.gaugeReportersMap[Goroutines] = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace:   "pitaya",

--- a/metrics/report.go
+++ b/metrics/report.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/topfreegames/pitaya/v2/constants"
 	"github.com/topfreegames/pitaya/v2/errors"
+	"github.com/topfreegames/pitaya/v2/logger"
 
 	pcontext "github.com/topfreegames/pitaya/v2/context"
 )
@@ -77,6 +78,41 @@ func ReportMessageProcessDelayFromCtx(ctx context.Context, reporters []Reporter,
 func ReportNumberOfConnectedClients(reporters []Reporter, number int64) {
 	for _, r := range reporters {
 		r.ReportGauge(ConnectedClients, map[string]string{}, float64(number))
+	}
+}
+
+// ReportChannelCapacity reports a channel's available capacity (free slots) as both
+// the deprecated channel_capacity gauge and the channel_capacity_histogram, tagged
+// with the given channel name. A warning is logged when the channel has no free slots.
+func ReportChannelCapacity(reporters []Reporter, channel string, available int) {
+	if available == 0 {
+		logger.Log.Warnf("channel %s is at maximum capacity", channel)
+	}
+	// a fresh labels map is built per call because some reporters (e.g. prometheus)
+	// mutate the map they receive, which would otherwise leak across reporters
+	for _, r := range reporters {
+		if err := r.ReportGauge(ChannelCapacity, map[string]string{"channel": channel}, float64(available)); err != nil {
+			logger.Log.Warnf("failed to report %s capacity gauge: %s", channel, err.Error())
+		}
+		if err := r.ReportHistogram(ChannelCapacityHistogram, map[string]string{"channel": channel}, float64(available)); err != nil {
+			logger.Log.Warnf("failed to report %s capacity histogram: %s", channel, err.Error())
+		}
+	}
+}
+
+// ReportWorkerPoolUsage reports the number of busy workers and the total worker count
+// of a goroutine pool, tagged with the given pool name. Together they describe the
+// pool's utilization (busy/total).
+func ReportWorkerPoolUsage(reporters []Reporter, pool string, busy, total int) {
+	// a fresh labels map is built per call because some reporters (e.g. prometheus)
+	// mutate the map they receive, which would otherwise leak across reporters
+	for _, r := range reporters {
+		if err := r.ReportGauge(WorkerPoolBusyWorkers, map[string]string{"pool": pool}, float64(busy)); err != nil {
+			logger.Log.Warnf("failed to report %s busy workers: %s", pool, err.Error())
+		}
+		if err := r.ReportGauge(WorkerPoolTotalWorkers, map[string]string{"pool": pool}, float64(total)); err != nil {
+			logger.Log.Warnf("failed to report %s total workers: %s", pool, err.Error())
+		}
 	}
 }
 

--- a/service/handler.go
+++ b/service/handler.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"net"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/nats-io/nuid"
@@ -73,6 +74,10 @@ type (
 		agentFactory     agent.AgentFactory
 		handlerPool      *HandlerPool
 		handlers         map[string]*component.Handler // all handler method
+		// dispatch worker pool counters (atomic): numDispatch is the number of running
+		// Dispatch goroutines, busyDispatch how many are currently processing a message
+		numDispatch  int32
+		busyDispatch int32
 	}
 
 	unhandledMessage struct {
@@ -120,16 +125,24 @@ func (h *HandlerService) Dispatch(thread int) {
 	// TODO: This timer is being stopped multiple times, it probably doesn't need to be stopped here
 	defer timer.GlobalTicker.Stop()
 
+	// register this goroutine as part of the dispatch worker pool so its utilization
+	// can be reported (see ReportMetrics)
+	atomic.AddInt32(&h.numDispatch, 1)
+
 	for {
 		// Calls to remote servers block calls to local server
 		select {
 		case lm := <-h.chLocalProcess:
 			metrics.ReportMessageProcessDelayFromCtx(lm.ctx, h.metricsReporters, "local")
+			atomic.AddInt32(&h.busyDispatch, 1)
 			h.localProcess(lm.ctx, lm.agent, lm.route, lm.msg)
+			atomic.AddInt32(&h.busyDispatch, -1)
 
 		case rm := <-h.chRemoteProcess:
 			metrics.ReportMessageProcessDelayFromCtx(rm.ctx, h.metricsReporters, "remote")
+			atomic.AddInt32(&h.busyDispatch, 1)
 			h.remoteService.remoteProcess(rm.ctx, nil, rm.agent, rm.route, rm.msg)
+			atomic.AddInt32(&h.busyDispatch, -1)
 
 		case <-timer.GlobalTicker.C: // execute cron task
 			timer.Cron()
@@ -141,6 +154,23 @@ func (h *HandlerService) Dispatch(thread int) {
 			timer.RemoveTimer(id)
 		}
 	}
+}
+
+// ReportMetrics reports the fill level of the handler dispatch channels and the
+// utilization of the dispatch worker pool. It does a single reporting pass and is
+// meant to be called periodically (see App.periodicMetrics).
+func (h *HandlerService) ReportMetrics() {
+	if len(h.metricsReporters) == 0 {
+		return
+	}
+	metrics.ReportChannelCapacity(h.metricsReporters, "handler_chlocalprocess", cap(h.chLocalProcess)-len(h.chLocalProcess))
+	metrics.ReportChannelCapacity(h.metricsReporters, "handler_chremoteprocess", cap(h.chRemoteProcess)-len(h.chRemoteProcess))
+	metrics.ReportWorkerPoolUsage(
+		h.metricsReporters,
+		"handler_dispatch",
+		int(atomic.LoadInt32(&h.busyDispatch)),
+		int(atomic.LoadInt32(&h.numDispatch)),
+	)
 }
 
 // Register registers components

--- a/service/handler_test.go
+++ b/service/handler_test.go
@@ -119,6 +119,35 @@ func TestNewHandlerService(t *testing.T) {
 	assert.Equal(t, handlerPool, svc.handlerPool)
 }
 
+func TestHandlerServiceReportMetrics(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockMetricsReporter := metricsmocks.NewMockReporter(ctrl)
+	mockMetricsReporters := []metrics.Reporter{mockMetricsReporter}
+	svc := NewHandlerService(
+		codec.NewPomeloPacketDecoder(),
+		json.NewSerializer(),
+		9, 8,
+		&cluster.Server{},
+		&RemoteService{},
+		agentmocks.NewMockAgentFactory(ctrl),
+		mockMetricsReporters,
+		pipeline.NewHandlerHooks(),
+		NewHandlerPool(),
+	)
+
+	// both dispatch channels are empty, so all buffer slots are available
+	mockMetricsReporter.EXPECT().ReportGauge(metrics.ChannelCapacity, gomock.Any(), float64(9))
+	mockMetricsReporter.EXPECT().ReportHistogram(metrics.ChannelCapacityHistogram, gomock.Any(), float64(9))
+	mockMetricsReporter.EXPECT().ReportGauge(metrics.ChannelCapacity, gomock.Any(), float64(8))
+	mockMetricsReporter.EXPECT().ReportHistogram(metrics.ChannelCapacityHistogram, gomock.Any(), float64(8))
+	// no Dispatch goroutines were started in this test, so the pool is empty and idle
+	mockMetricsReporter.EXPECT().ReportGauge(metrics.WorkerPoolBusyWorkers, gomock.Any(), float64(0))
+	mockMetricsReporter.EXPECT().ReportGauge(metrics.WorkerPoolTotalWorkers, gomock.Any(), float64(0))
+
+	svc.ReportMetrics()
+}
+
 func TestHandlerServiceRegister(t *testing.T) {
 	handlerPool := NewHandlerPool()
 	svc := NewHandlerService(nil, nil, 0, 0, nil, nil, nil, nil, nil, handlerPool)


### PR DESCRIPTION
Several buffered channels and goroutine pools that sit on the hot path had no instrumentation, so there was no way to tell from metrics when a server was hitting its buffer (BUFFER_*) or concurrency (CONCURRENCY_*) limits — the channels would just fill and apply backpressure silently.

Add capacity/utilization metrics for the previously-unmonitored ones:

Channel capacity (reuses channel_capacity_histogram, new `channel` tags):
  - handler_chlocalprocess   (buffer.handler.localprocess)
  - handler_chremoteprocess  (buffer.handler.remoteprocess)
  - rpc_server_userkickchan  (shares the nats messages buffer)

Worker-pool utilization (new gauges pitaya_worker_pool_busy_workers and pitaya_worker_pool_total_workers, tagged by `pool`):
  - handler_dispatch    (concurrency.handler.dispatch)
  - rpc_server_remote   (cluster.rpc.server.nats.services)

Implementation:
  - Handler dispatch channels and pool are sampled periodically from App.periodicMetrics (no extra work on the per-message path).
  - userKickCh and the remote pool are reported from the existing nats reportMetrics, alongside the channels already covered there.
  - Add metrics.ReportChannelCapacity / ReportWorkerPoolUsage helpers and refactor nats reportMetrics to use them; each call builds its own label map so prometheus's label mutation can't leak across reporters.

Busy-worker counts are tracked with atomic int32 counters (two adds per message, dwarfed by the actual handler/RPC work). Purely additive — no existing metric, behaviour, or config is changed; works on both the prometheus and statsd reporters.